### PR TITLE
Broadcast via node

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -56,6 +56,24 @@ pub struct Arguments {
     /// If not provided is randomly generated.
     #[arg(long, env)]
     pub server_key: Option<Identity>,
+
+    /// Elements node rpc user and password, separated by ':' (same as the content of the cookie file)
+    ///
+    /// RPC connection is needed for broadcasting transaction via the `sendrawtransaction` call which is not present in the REST interface.
+    /// It's an error if `use_esplora` is false and this is missing.
+    pub rpc_user_password: Option<String>,
+}
+
+impl Arguments {
+    pub fn is_valid(&self) -> Result<(), Error> {
+        if !self.use_esplora && self.rpc_user_password.is_none() {
+            Err(Error::String(
+                "When using the node you must specify user and password".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -111,6 +129,8 @@ pub async fn inner_main(
     args: Arguments,
     shutdown_signal: impl Future<Output = ()>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    args.is_valid()?;
+
     // TODO test rest connection to the node
 
     let store = get_store(&args)?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -191,7 +191,7 @@ pub async fn inner_main(
             },
 
             _ = &mut signal => {
-                log::error!("graceful shutdown signal received");
+                log::info!("graceful shutdown signal received");
                 // stop the accept loop
                 break;
             }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -62,6 +62,9 @@ async fn inner_launch_with_node(elementsd: BitcoinD, path: Option<PathBuf>) -> T
     let server_key = Identity::generate();
     args.server_key = Some(server_key.clone());
 
+    let cookie = std::fs::read_to_string(&elementsd.params.cookie_file).unwrap();
+    args.rpc_user_password = Some(cookie);
+
     #[cfg(feature = "db")]
     {
         args.datadir = path;


### PR DESCRIPTION
Before this the tx broadcast was made always via esplora, with this the broadcast is made via the node if waterfall is syncing through the node. To do this it's required the RPC authentication 