### PR TITLE
Add a `to_index` param to waterfalls descriptor request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,13 @@ pub struct DescriptorRequest {
         elements_miniscript::descriptor::Descriptor<elements_miniscript::DescriptorPublicKey>,
 
     /// Requested page, 0 if not specified
-    /// The first returned index is equal to `page * 1000`
+    /// The first returned index is equal to `page * 10000`
     /// The same page is used for all the descriptor (ie both external and internal)
     page: u16,
+
+    /// The last known derivation index to scan up to, 0 if not specified
+    /// This can be used to override the GAP_LIMIT
+    to_index: u32,
 }
 
 /// Request to the waterfalls endpoint using a list of addresses
@@ -45,7 +49,7 @@ pub struct AddressesRequest {
     addresses: Vec<elements::Address>,
 
     /// Requested page, 0 if not specified
-    /// The first returned index is equal to `page * 1000`
+    /// The first returned index is equal to `page * 10000`
     page: u16,
 }
 


### PR DESCRIPTION
We are using the LWK's `full_scan_to_index()` function make sure we are scanning up to our own cached derivation index to avoid any issues with the gap limit. We'd like to leverage the same functionally when using esplora/waterfalls for our Wasm SDK also.

I've also updated the comments `page * 1000` to `page * 10000` because I feel like it should be `page * MAX_ADDRESSES`. Let know know if this is wrong.