### PR TITLE
Add history of the spend for the script hash of the previous output

### DIFF
--- a/src/threads/blocks.rs
+++ b/src/threads/blocks.rs
@@ -62,11 +62,14 @@ pub async fn index(state: Arc<State>, client: Client) -> Result<(), Error> {
                         continue;
                     }
                     match utxo_created.remove(&input.previous_output) {
-                        Some(_) => {
+                        Some(script_hash) => {
                             log::debug!("spent same block, avoiding {}", &input.previous_output);
                             // spent in the same block:
                             // - no need to remove from the persisted utxo
                             // - this height already inserted for this script from the relative same-height output
+                            // Update the history map, adding history of the spend for the previous output script
+                            let el = history_map.entry(script_hash).or_insert(vec![]);
+                            el.push(TxSeen::new(txid, block_height));
                         }
                         None => {
                             log::debug!("removing {}", &input.previous_output);


### PR DESCRIPTION
If a block update contains a UTXO that is spent in the same block, the script history of the spending script is missing history of the spend.

This fix probably means that the DB's history needs rebuilding.

Fixes #8 