### PR TITLE
Improve error handling and log error context

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -15,6 +15,7 @@ use tokio::time::sleep;
 
 use crate::server::{Arguments, Network};
 
+#[derive(Clone)]
 pub struct Client {
     client: reqwest::Client,
     use_esplora: bool,


### PR DESCRIPTION
We've observed an error in the blocks thread causing the blocks updates to stall because the `index` fn exits:
```log
May 15 04:04:17 elements waterfalls[691968]: [2025-05-15T02:04:17Z INFO  waterfalls::server::route] returning: 6 elements, elapsed: 0ms
May 15 04:04:17 elements waterfalls[691968]: [2025-05-15T02:04:17Z INFO  waterfalls::threads::mempool] removed txs from mempool [c49a7e07945e75b1fbd9149fdbf1fab72901633815893ac665e3b749f2588ef3, 34a7ae0465af3d5c0a1b0b412f9b4ca9d3d509d89735b44da3c9f35fa100f4f0, 99f5914195b91091e86f6c22ec4d08725eb6a03b07d835431974f78c13919935], tip: Some(3375085)
May 15 04:04:17 elements waterfalls[691968]: [2025-05-15T02:04:17Z ERROR waterfalls::threads::blocks] Other
```

This PR:
- Updates the `index` fn to log the error source
- Calls `set_hash_ts` fn only after successfully calling `db.update` fn
- Updates `blocks_infallible` fn to handle the error in a loop
- Adds a shutdown handler to gracefully exit the `blocks_infallible` loop