### PR TITLE
Add  `OutPoint` struct for both bitcoin and elements

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -7,14 +7,14 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use hyper::body::Buf;
 
 use elements::secp256k1_zkp::rand::{thread_rng, RngCore};
-use elements::{OutPoint, Txid};
+use elements::Txid;
 use elements_miniscript::Descriptor;
 use elements_miniscript::DescriptorPublicKey;
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Options, WriteBatch, DB,
 };
 use tempfile;
-use waterfalls::WaterfallResponse;
+use waterfalls::{OutPoint, WaterfallResponse};
 
 criterion_group!(
     benches,
@@ -189,7 +189,7 @@ pub fn writebatch_sorting(c: &mut Criterion) {
         rng.fill_bytes(&mut txid_bytes);
         let txid = Txid::from_byte_array(txid_bytes);
         let vout = rng.next_u32();
-        test_outpoints.push(OutPoint { txid, vout });
+        test_outpoints.push(OutPoint::new(txid.into(), vout));
     }
 
     // Helper function to serialize OutPoint

--- a/src/be/mod.rs
+++ b/src/be/mod.rs
@@ -2,6 +2,7 @@ mod address;
 mod block;
 mod block_header;
 mod descriptor;
+mod outpoint;
 mod transaction;
 mod txid;
 
@@ -9,6 +10,7 @@ pub use address::Address;
 pub use block::Block;
 pub use block_header::BlockHeader;
 pub use descriptor::{bitcoin_descriptor, Descriptor};
+pub use outpoint::OutPoint;
 pub use transaction::{Input, InputRef, Output, OutputRef, Transaction, TransactionRef};
 pub use txid::Txid;
 

--- a/src/be/outpoint.rs
+++ b/src/be/outpoint.rs
@@ -1,0 +1,207 @@
+use std::str::FromStr;
+
+use crate::be::Txid;
+
+/// A network-agnostic transaction outpoint.
+///
+/// Binary encoding intentionally matches both bitcoin::OutPoint and elements::OutPoint:
+/// 32 bytes of txid in consensus order, followed by 4 bytes of little-endian vout.
+#[derive(Clone, PartialEq, Eq, Debug, Copy, Ord, PartialOrd, Hash)]
+pub struct OutPoint {
+    pub txid: Txid,
+    pub vout: u32,
+}
+
+impl OutPoint {
+    pub const SIZE: usize = 36;
+
+    pub const fn new(txid: Txid, vout: u32) -> Self {
+        Self { txid, vout }
+    }
+
+    pub fn null() -> Self {
+        Self::new(Txid::all_zeros(), u32::MAX)
+    }
+}
+
+impl From<bitcoin::OutPoint> for OutPoint {
+    fn from(outpoint: bitcoin::OutPoint) -> Self {
+        Self::new(outpoint.txid.into(), outpoint.vout)
+    }
+}
+
+impl From<elements::OutPoint> for OutPoint {
+    fn from(outpoint: elements::OutPoint) -> Self {
+        Self::new(outpoint.txid.into(), outpoint.vout)
+    }
+}
+
+impl FromStr for OutPoint {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (txid, vout) = s
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("Invalid outpoint format"))?;
+        let txid = Txid::from_str(txid)?;
+        let vout = vout.parse()?;
+        Ok(Self::new(txid, vout))
+    }
+}
+
+impl std::fmt::Display for OutPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.txid, self.vout)
+    }
+}
+
+impl elements::encode::Encodable for OutPoint {
+    fn consensus_encode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> Result<usize, elements::encode::Error> {
+        elements::WriteExt::emit_slice(&mut writer, self.txid.as_byte_array())?;
+        elements::WriteExt::emit_u32(&mut writer, self.vout)?;
+        Ok(Self::SIZE)
+    }
+}
+
+impl elements::encode::Decodable for OutPoint {
+    fn consensus_decode<R: std::io::Read>(mut reader: R) -> Result<Self, elements::encode::Error> {
+        let mut txid = [0u8; 32];
+        reader.read_exact(&mut txid)?;
+        let mut vout = [0u8; 4];
+        reader.read_exact(&mut vout)?;
+        let txid = Txid::from_array(txid);
+        let vout = u32::from_le_bytes(vout);
+        Ok(Self::new(txid, vout))
+    }
+}
+
+#[cfg(test)]
+impl OutPoint {
+    pub fn bitcoin(self) -> bitcoin::OutPoint {
+        bitcoin::OutPoint::new(self.txid.bitcoin(), self.vout)
+    }
+
+    pub fn elements(self) -> elements::OutPoint {
+        elements::OutPoint::new(self.txid.elements(), self.vout)
+    }
+
+    pub fn to_bytes(self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        bytes[..32].copy_from_slice(self.txid.as_byte_array());
+        bytes[32..].copy_from_slice(&self.vout.to_le_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: [u8; Self::SIZE]) -> Self {
+        let txid = Txid::from_array(bytes[..32].try_into().expect("slice has exact size"));
+        let vout = u32::from_le_bytes(bytes[32..].try_into().expect("slice has exact size"));
+        Self::new(txid, vout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::consensus::{
+        deserialize as bitcoin_deserialize, serialize as bitcoin_serialize, WriteExt,
+    };
+    use elements::encode::{deserialize as elements_deserialize, serialize as elements_serialize};
+
+    impl bitcoin::consensus::Encodable for OutPoint {
+        fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+            &self,
+            writer: &mut W,
+        ) -> Result<usize, bitcoin::io::Error> {
+            writer.emit_slice(self.txid.as_byte_array())?;
+            writer.emit_u32(self.vout)?;
+            Ok(36)
+        }
+    }
+
+    impl bitcoin::consensus::Decodable for OutPoint {
+        fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
+            reader: &mut R,
+        ) -> Result<Self, bitcoin::consensus::encode::Error> {
+            let mut txid = [0u8; 32];
+            reader.read_exact(&mut txid)?;
+            let mut vout = [0u8; 4];
+            reader.read_exact(&mut vout)?;
+            let txid = Txid::from_array(txid);
+            let vout = u32::from_le_bytes(vout);
+            Ok(Self::new(txid, vout))
+        }
+    }
+
+    fn sample_outpoint() -> OutPoint {
+        OutPoint::from_str("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f:42")
+            .unwrap()
+    }
+
+    #[test]
+    fn test_outpoint_string_roundtrip() {
+        let outpoint = sample_outpoint();
+        assert_eq!(
+            outpoint.to_string(),
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f:42"
+        );
+        assert_eq!(OutPoint::from_str(&outpoint.to_string()).unwrap(), outpoint);
+    }
+
+    #[test]
+    fn test_outpoint_conversion_roundtrip() {
+        let outpoint = sample_outpoint();
+        assert_eq!(OutPoint::from(outpoint.bitcoin()), outpoint);
+        assert_eq!(OutPoint::from(outpoint.elements()), outpoint);
+    }
+
+    #[test]
+    fn test_outpoint_binary_encoding_matches_bitcoin_and_elements() {
+        let outpoint = sample_outpoint();
+
+        let ours = outpoint.to_bytes();
+        let bitcoin = bitcoin_serialize(&outpoint.bitcoin());
+        let elements = elements_serialize(&outpoint.elements());
+
+        assert_eq!(bitcoin.len(), OutPoint::SIZE);
+        assert_eq!(elements.len(), OutPoint::SIZE);
+        assert_eq!(ours.as_slice(), bitcoin.as_slice());
+        assert_eq!(ours.as_slice(), elements.as_slice());
+    }
+
+    #[test]
+    fn test_outpoint_binary_decoding_matches_bitcoin_and_elements() {
+        let outpoint = sample_outpoint();
+        let bytes = outpoint.to_bytes();
+
+        let from_bitcoin: bitcoin::OutPoint = bitcoin_deserialize(&bytes).unwrap();
+        let from_elements: elements::OutPoint = elements_deserialize(&bytes).unwrap();
+
+        assert_eq!(OutPoint::from(from_bitcoin), outpoint);
+        assert_eq!(OutPoint::from(from_elements), outpoint);
+    }
+
+    #[test]
+    fn test_outpoint_our_traits_match_bitcoin_and_elements_bytes() {
+        let bitcoin_outpoint = bitcoin::OutPoint::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111:7",
+        )
+        .unwrap();
+        let elements_outpoint = elements::OutPoint::from_str(
+            "1111111111111111111111111111111111111111111111111111111111111111:7",
+        )
+        .unwrap();
+        let our_outpoint = OutPoint::from(bitcoin_outpoint);
+
+        let bitcoin_bytes = bitcoin_serialize(&bitcoin_outpoint);
+        let elements_bytes = elements_serialize(&elements_outpoint);
+        let our_bitcoin_bytes = bitcoin_serialize(&our_outpoint);
+        let our_elements_bytes = elements_serialize(&our_outpoint);
+
+        assert_eq!(bitcoin_bytes, elements_bytes);
+        assert_eq!(our_bitcoin_bytes, bitcoin_bytes);
+        assert_eq!(our_elements_bytes, elements_bytes);
+    }
+}

--- a/src/be/transaction.rs
+++ b/src/be/transaction.rs
@@ -209,13 +209,10 @@ impl InputRef<'_> {
         }
     }
 
-    pub(crate) fn previous_output(&self) -> elements::OutPoint {
+    pub(crate) fn previous_output(&self) -> crate::OutPoint {
         match self {
-            InputRef::Bitcoin(input) => elements::OutPoint::new(
-                crate::be::Txid::from(input.previous_output.txid).elements(),
-                input.previous_output.vout,
-            ),
-            InputRef::Elements(input) => input.previous_output,
+            InputRef::Bitcoin(input) => input.previous_output.into(),
+            InputRef::Elements(input) => input.previous_output.into(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use crate::cbor::{cbor_block_hash, cbor_opt_block_hash};
 pub use be::Family;
-use elements::{BlockHash, OutPoint};
+pub use be::OutPoint;
+use elements::BlockHash;
 use lazy_static::lazy_static;
 use minicbor::{Decode, Encode};
 use prometheus::{
@@ -287,9 +288,7 @@ impl TxSeen {
     }
 
     pub fn outpoint(&self) -> Option<OutPoint> {
-        self.v
-            .vout()
-            .map(|vout| OutPoint::new(self.txid.elements(), vout))
+        self.v.vout().map(|vout| OutPoint::new(self.txid, vout))
     }
 }
 

--- a/src/server/mempool.rs
+++ b/src/server/mempool.rs
@@ -3,12 +3,10 @@ use std::{
     iter,
 };
 
-use elements::OutPoint;
-
 use crate::{
     be,
     store::{AnyStore, Store},
-    ScriptHash, TxSeen, V,
+    OutPoint, ScriptHash, TxSeen, V,
 };
 
 pub struct Mempool {
@@ -59,7 +57,7 @@ impl Mempool {
             .flat_map(|(txid, tx)| tx.outputs_iter().enumerate().zip(iter::repeat(txid)))
             .map(|((vout, txout), txid)| {
                 (
-                    OutPoint::new(txid.elements(), vout as u32),
+                    OutPoint::new(*txid, vout as u32),
                     db.hash(txout.script_pubkey_bytes()),
                 )
             });

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -286,16 +286,8 @@ pub async fn route(
                 (Some(""), Some("v1"), Some("unspent"), Some(outpoint), None) => {
                     // note this method only considers confirmed utxos
                     // outpoint is of the form txid:vout
-                    // manual outpoint parsing because elements::OutPoint has [elements] prefix
-                    let mut parts = outpoint.split(":");
-                    let txid = parts.next().ok_or(Error::InvalidOutpoint)?;
-                    let vout = parts.next().ok_or(Error::InvalidOutpoint)?;
-                    if parts.next().is_some() {
-                        return Err(Error::InvalidOutpoint);
-                    }
-                    let txid = elements::Txid::from_str(txid).map_err(|_| Error::InvalidTxid)?;
-                    let vout = vout.parse::<u32>().map_err(|_| Error::InvalidOutpoint)?;
-                    let outpoint = elements::OutPoint::new(txid, vout);
+                    let outpoint =
+                        crate::OutPoint::from_str(outpoint).map_err(|_| Error::InvalidOutpoint)?;
                     let state = state
                         .store
                         .get_utxos(&[outpoint])

--- a/src/store/db.rs
+++ b/src/store/db.rs
@@ -3,7 +3,7 @@ use elements::{
     encode::Encodable,
     hashes::Hash,
     secp256k1_zkp::rand::{thread_rng, Rng},
-    BlockHash, OutPoint,
+    BlockHash,
 };
 use fxhash::FxHasher;
 use rocksdb::{
@@ -27,7 +27,7 @@ use std::{
 use crate::{
     error_panic,
     store::{BlockMeta, Store, TxSeen},
-    Height, ScriptHash,
+    Height, OutPoint, ScriptHash,
 };
 
 /// RocksDB wrapper for index storage
@@ -783,7 +783,7 @@ fn concat_merge(
 
 #[cfg(test)]
 mod test {
-    use elements::{hashes::Hash, BlockHash, OutPoint, Txid};
+    use elements::{hashes::Hash, BlockHash, Txid};
     use rocksdb::DB;
     use std::{collections::BTreeMap, sync::atomic::AtomicBool};
 
@@ -924,32 +924,17 @@ mod test {
             rng.fill_bytes(&mut txid_bytes);
             let txid = Txid::from_byte_array(txid_bytes);
             let vout = rng.next_u32();
-            outpoints.push(OutPoint { txid, vout });
+            outpoints.push(OutPoint::new(txid.into(), vout));
         }
 
         // Add some specific test cases to ensure edge cases work
         let zero_txid = Txid::all_zeros();
         let max_txid = Txid::from_byte_array([0xff; 32]);
-        outpoints.push(OutPoint {
-            txid: zero_txid,
-            vout: 0,
-        });
-        outpoints.push(OutPoint {
-            txid: zero_txid,
-            vout: 1,
-        });
-        outpoints.push(OutPoint {
-            txid: zero_txid,
-            vout: u32::MAX,
-        });
-        outpoints.push(OutPoint {
-            txid: max_txid,
-            vout: 0,
-        });
-        outpoints.push(OutPoint {
-            txid: max_txid,
-            vout: u32::MAX,
-        });
+        outpoints.push(OutPoint::new(zero_txid.into(), 0));
+        outpoints.push(OutPoint::new(zero_txid.into(), 1));
+        outpoints.push(OutPoint::new(zero_txid.into(), u32::MAX));
+        outpoints.push(OutPoint::new(max_txid.into(), 0));
+        outpoints.push(OutPoint::new(max_txid.into(), u32::MAX));
 
         // Sort by PartialOrd
         let mut outpoints_by_ord = outpoints.clone();

--- a/src/store/db.rs
+++ b/src/store/db.rs
@@ -794,6 +794,7 @@ mod test {
         },
         Store,
     };
+    use crate::OutPoint;
     use crate::V;
 
     use super::DBStore;
@@ -824,7 +825,7 @@ mod test {
         let salt2 = get_or_init_salt(&db.db).unwrap();
         assert_eq!(salt, salt2);
 
-        let o = OutPoint::default();
+        let o = OutPoint::null();
         let o1 = {
             let mut o1 = o;
             o1.vout = 1;

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -1,9 +1,8 @@
 use std::{collections::BTreeMap, hash::Hasher, sync::Mutex};
 
-use elements::OutPoint;
 use fxhash::FxHasher;
 
-use crate::{error_panic, Height, ScriptHash};
+use crate::{error_panic, Height, OutPoint, ScriptHash};
 
 use super::{BlockMeta, Store, TxSeen};
 use crate::V;
@@ -30,7 +29,7 @@ impl Store for MemoryStore {
 
     fn get_utxos(
         &self,
-        outpoints: &[elements::OutPoint],
+        outpoints: &[OutPoint],
     ) -> anyhow::Result<Vec<Option<ScriptHash>>> {
         let mut result = Vec::with_capacity(outpoints.len());
         for outpoint in outpoints {
@@ -60,9 +59,9 @@ impl Store for MemoryStore {
     fn update(
         &self,
         block_meta: &BlockMeta,
-        utxo_spent: Vec<(u32, elements::OutPoint, crate::be::Txid)>,
+        utxo_spent: Vec<(u32, OutPoint, crate::be::Txid)>,
         history_map: std::collections::BTreeMap<ScriptHash, Vec<TxSeen>>,
-        utxo_created: std::collections::BTreeMap<elements::OutPoint, ScriptHash>,
+        utxo_created: std::collections::BTreeMap<OutPoint, ScriptHash>,
     ) -> anyhow::Result<()> {
         let mut history_map = history_map;
         let only_outpoints: Vec<_> = utxo_spent.iter().map(|e| e.1).collect();
@@ -199,9 +198,9 @@ mod tests {
         let source_script_hash = 11;
         let recipient_script_hash = 22;
         let one = "1111111111111111111111111111111111111111111111111111111111111111";
-        let source_outpoint = OutPoint::new(elements::Txid::from_str(one).unwrap(), 0);
+        let source_outpoint = OutPoint::new(crate::be::Txid::from_str(one).unwrap(), 0);
         let two = "2222222222222222222222222222222222222222222222222222222222222222";
-        let created_outpoint = OutPoint::new(elements::Txid::from_str(two).unwrap(), 1);
+        let created_outpoint = OutPoint::new(crate::be::Txid::from_str(two).unwrap(), 1);
         store
             .utxos
             .lock()

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -1,6 +1,6 @@
-use crate::{Height, ScriptHash, Timestamp, TxSeen};
+use crate::{Height, OutPoint, ScriptHash, Timestamp, TxSeen};
 use anyhow::Result;
-use elements::{BlockHash, OutPoint};
+use elements::BlockHash;
 use std::collections::BTreeMap;
 
 #[cfg(feature = "db")]

--- a/src/store/reorg_data.rs
+++ b/src/store/reorg_data.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use elements::OutPoint;
 use std::collections::BTreeMap;
 
-use crate::{store::TxSeen, ScriptHash};
+use crate::{store::TxSeen, OutPoint, ScriptHash};
 
 use super::db::{vec_tx_seen_from_be_bytes, vec_tx_seen_to_be_bytes};
 
@@ -131,14 +130,12 @@ mod test {
 
     #[test]
     fn test_reorg_data_roundtrip() {
-        use elements::{hashes::Hash, OutPoint, Txid};
-
         // Create a ReorgData with all fields populated
         let mut reorg_data = ReorgData::default();
 
         // Add some spent UTXOs
-        let txid1 = Txid::from_slice(&[1u8; 32]).unwrap();
-        let txid2 = Txid::from_slice(&[2u8; 32]).unwrap();
+        let txid1 = crate::be::Txid::from_slice(&[1u8; 32]).unwrap();
+        let txid2 = crate::be::Txid::from_slice(&[2u8; 32]).unwrap();
         let outpoint1 = OutPoint::new(txid1, 0);
         let outpoint2 = OutPoint::new(txid2, 1);
         reorg_data.spent.push((outpoint1, 123456789u64));
@@ -167,8 +164,8 @@ mod test {
             .insert(script_hash2, vec![tx_seen1.clone(), tx_seen2.clone()]);
 
         // Add some created UTXOs
-        let txid3 = Txid::from_slice(&[5u8; 32]).unwrap();
-        let txid4 = Txid::from_slice(&[6u8; 32]).unwrap();
+        let txid3 = crate::be::Txid::from_slice(&[5u8; 32]).unwrap();
+        let txid4 = crate::be::Txid::from_slice(&[6u8; 32]).unwrap();
         let outpoint3 = OutPoint::new(txid3, 2);
         let outpoint4 = OutPoint::new(txid4, 3);
         reorg_data.utxos_created.insert(outpoint3, 333333u64);

--- a/src/threads/blocks.rs
+++ b/src/threads/blocks.rs
@@ -3,9 +3,9 @@ use crate::{
     fetch::{ChainStatus, Client},
     server::{Error, State},
     store::{BlockMeta, Store},
-    TxSeen, V,
+    OutPoint, TxSeen, V,
 };
-use elements::{OutPoint, Txid};
+use elements::Txid;
 use std::{
     collections::{BTreeMap, HashSet},
     future::Future,
@@ -214,7 +214,7 @@ pub async fn index(
             for (j, output) in tx.outputs_iter().enumerate() {
                 if !output.skip_utxo() {
                     // We skip utxos only when we are sure they are not spendable.
-                    let out_point = OutPoint::new(txid.elements(), j as u32);
+                    let out_point = OutPoint::new(txid, j as u32);
                     utxo_created.insert(out_point, db.hash(b""));
                 }
                 if output.skip_indexing() {
@@ -224,7 +224,7 @@ pub async fn index(
                 let el = history_map.entry(script_hash).or_insert(vec![]);
                 el.push(TxSeen::new(txid, block_to_index.height, V::Vout(j as u32)));
 
-                let out_point = OutPoint::new(txid.elements(), j as u32);
+                let out_point = OutPoint::new(txid, j as u32);
                 log::debug!("inserting {out_point}");
                 utxo_created.insert(out_point, script_hash);
             }
@@ -262,7 +262,7 @@ pub async fn index(
 
 fn generate_skip_outpoint() -> HashSet<OutPoint> {
     let mut skip_outpoint = HashSet::new();
-    let outpoint = |txid, vout| OutPoint::new(Txid::from_str(txid).expect("static"), vout);
+    let outpoint = |txid, vout| OutPoint::new(Txid::from_str(txid).expect("static").into(), vout);
 
     // policy asset emission in testnet
     let s = "0c52d2526a5c9f00e9fb74afd15dd3caaf17c823159a514f929ae25193a43a52";


### PR DESCRIPTION
Before this MR we were using elements::OutPoint also for bitcoin. In practice this is fine because consensus encoding is the same, but it's not great, for example we see in logs "[elements]00000000020342032424242:2" as outpoint representation even if the network is bitcoin, and this is confounding.

also the manual outpoint parsing in the unspent route is not needed anymore