### PR TITLE
pre-warm transaction cache for mempool sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -429,6 +429,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
@@ -511,6 +517,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -730,6 +746,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +782,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -873,6 +920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dircpy"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
+dependencies = [
+ "jwalk",
+ "log",
+ "walkdir",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +1055,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1849,6 +1907,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,7 +2302,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2487,7 +2555,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -2500,7 +2568,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "hex",
 ]
 
@@ -2684,7 +2752,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2863,7 +2931,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2876,7 +2944,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
@@ -3044,7 +3112,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3130,6 +3198,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -3322,7 +3399,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3336,6 +3413,25 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -3443,6 +3539,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tmq"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f41ac3a42f65436eed7e1afe80dbe8a982dcac2ea4581bf61bc2d3dcfb19a1"
+dependencies = [
+ "futures",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+ "zmq",
+]
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +3635,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3707,6 +3850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,6 +3987,7 @@ dependencies = [
  "elements-miniscript",
  "env_logger",
  "form_urlencoded",
+ "futures-util",
  "fxhash",
  "hex-simd",
  "http-body-util",
@@ -3857,6 +4007,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tmq",
  "tokio",
 ]
 
@@ -4173,12 +4324,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4291,6 +4451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeromq-src"
+version = "0.2.6+4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc120b771270365d5ed0dfb4baf1005f2243ae1ae83703265cb3504070f4160b"
+dependencies = [
+ "cc",
+ "dircpy",
+]
+
+[[package]]
 name = "zerovec"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,6 +4480,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "zmq"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd3091dd571fb84a9b3e5e5c6a807d186c411c812c8618786c3c30e5349234e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "zmq-sys",
+]
+
+[[package]]
+name = "zmq-sys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8351dc72494b4d7f5652a681c33634063bbad58046c1689e75270908fdc864"
+dependencies = [
+ "libc",
+ "system-deps",
+ "zeromq-src",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ http-body-util = "0.1"
 hyper-util = { version = "0.1.5", features = ["full", "server"] }
 reqwest = "0.12.12"
 anyhow = "1.0.86"
+futures-util = "0.3.31"
 rocksdb = { version = "0.24.0", features = [
     "multi-threaded-cf",
     "zstd",
@@ -53,6 +54,7 @@ minicbor = { version = "0.23", default-features = false, features = [
 prefix_uvarint = "0.6.1"
 lrumap = "0.1.0"
 hex-simd = "0.8.0"
+tmq = "0.5.0"
 
 
 [dev-dependencies]

--- a/src/server/mempool.rs
+++ b/src/server/mempool.rs
@@ -30,7 +30,17 @@ impl Mempool {
         }
     }
 
-    pub fn remove(&mut self, txids: &[crate::be::Txid]) {
+    pub fn update(
+        &mut self,
+        db: &AnyStore,
+        removed_txids: &[crate::be::Txid],
+        txs: &[(crate::be::Txid, be::Transaction)],
+    ) {
+        self.remove(removed_txids);
+        self.add(db, txs);
+    }
+
+    fn remove(&mut self, txids: &[crate::be::Txid]) {
         for txid in txids {
             if let Some(hashes) = self.txid_hashes.remove(txid) {
                 for hash in hashes {
@@ -47,7 +57,7 @@ impl Mempool {
             .retain(|k, _| !txids.contains(&k.txid.into()));
     }
 
-    pub fn add(&mut self, db: &AnyStore, txs: &[(crate::be::Txid, be::Transaction)]) {
+    fn add(&mut self, db: &AnyStore, txs: &[(crate::be::Txid, be::Transaction)]) {
         let txs_map: HashMap<crate::be::Txid, &be::Transaction> =
             txs.iter().map(|(txid, tx)| (*txid, tx)).collect();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,6 +13,7 @@ use crate::store::memory::MemoryStore;
 use crate::store::AnyStore;
 use crate::threads::blocks::blocks_infallible;
 use crate::threads::mempool::mempool_sync_infallible;
+use crate::threads::zmq::rawtx_listener_infallible;
 use age::x25519::Identity;
 use bitcoin::{NetworkKind, PrivateKey};
 use hyper::server::conn::http1;
@@ -89,6 +90,10 @@ pub struct Arguments {
     #[arg(long, env)]
     pub rpc_user_password: Option<String>,
 
+    /// Optional ZMQ endpoint used to subscribe to node raw transaction notifications.
+    #[arg(long, env)]
+    pub zmq_endpoint: Option<String>,
+
     /// Maximum number of addresses that can be specified in the query string.
     #[arg(env, long, default_value = "100")]
     pub max_addresses: usize,
@@ -158,6 +163,7 @@ impl std::fmt::Debug for Arguments {
                 "rpc_user_password",
                 &self.rpc_user_password.as_ref().map(|_| "Some(<redacted>)"),
             )
+            .field("zmq_endpoint", &self.zmq_endpoint)
             .field("max_addresses", &self.max_addresses)
             .field("add_cors", &self.add_cors)
             .field("derivation_cache_capacity", &self.derivation_cache_capacity)
@@ -435,6 +441,18 @@ pub async fn inner_main(
         })
     };
 
+    let h3 = args.zmq_endpoint.clone().map(|endpoint| {
+        let family = args.network.into();
+        let shutdown_rx = shutdown_tx.subscribe();
+        tokio::spawn(async move {
+            let shutdown_future = async {
+                let mut rx = shutdown_rx;
+                let _ = rx.recv().await;
+            };
+            rawtx_listener_infallible(endpoint, family, shutdown_future).await
+        })
+    });
+
     let addr = args.listen.unwrap_or(SocketAddr::from((
         [127, 0, 0, 1],
         args.network.default_listen_port(),
@@ -499,6 +517,9 @@ pub async fn inner_main(
 
     h1.await.unwrap();
     h2.await.unwrap();
+    if let Some(h3) = h3 {
+        h3.await.unwrap();
+    }
 
     log::info!("shutting down gracefully");
     Ok(())

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -442,6 +442,7 @@ pub async fn inner_main(
     };
 
     let h3 = args.zmq_endpoint.clone().map(|endpoint| {
+        let state = state.clone();
         let family = args.network.into();
         let shutdown_rx = shutdown_tx.subscribe();
         tokio::spawn(async move {
@@ -449,7 +450,7 @@ pub async fn inner_main(
                 let mut rx = shutdown_rx;
                 let _ = rx.recv().await;
             };
-            rawtx_listener_infallible(endpoint, family, shutdown_future).await
+            rawtx_listener_infallible(state, endpoint, family, shutdown_future).await
         })
     });
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -28,6 +28,7 @@ pub struct State {
 
     pub store: AnyStore,
     pub mempool: Mutex<Mempool>,
+    pub mempool_cache: Mutex<HashMap<crate::be::Txid, crate::be::Transaction>>,
     pub blocks_hash_ts: Mutex<Vec<(BlockHash, Timestamp)>>, // TODO should be moved into the Store, but in memory for db
 
     pub secp: Secp256k1<All>,
@@ -57,6 +58,7 @@ impl State {
             wif_key,
             store,
             mempool: Mutex::new(Mempool::new()),
+            mempool_cache: Mutex::new(HashMap::new()),
             blocks_hash_ts: Mutex::new(Vec::new()),
             secp: bitcoin::key::Secp256k1::new(),
             max_addresses,

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -27,10 +27,7 @@ impl Store for MemoryStore {
         Box::new(vec![].into_iter())
     }
 
-    fn get_utxos(
-        &self,
-        outpoints: &[OutPoint],
-    ) -> anyhow::Result<Vec<Option<ScriptHash>>> {
+    fn get_utxos(&self, outpoints: &[OutPoint]) -> anyhow::Result<Vec<Option<ScriptHash>>> {
         let mut result = Vec::with_capacity(outpoints.len());
         for outpoint in outpoints {
             result.push(self.utxos.lock().unwrap().get(outpoint).cloned());

--- a/src/threads/mempool.rs
+++ b/src/threads/mempool.rs
@@ -5,7 +5,7 @@ use crate::{
     store::Store,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     future::Future,
     sync::Arc,
     time::{Duration, Instant},
@@ -28,7 +28,6 @@ async fn sync_mempool_once(
     client: &Client,
     support_verbose: bool,
     mempool_txids: &mut HashSet<crate::be::Txid>,
-    mempool_cache: &mut HashMap<crate::be::Txid, crate::be::Transaction>,
     state: &Arc<State>,
     family: Family,
 ) -> Result<MempoolSyncStats, Error> {
@@ -45,6 +44,10 @@ async fn sync_mempool_once(
                 log::debug!("new txs in mempool {:?}, tip: {tip:?}", new);
             }
 
+            // we keep this lock because we are the critical path
+            // it's fine if the zmq thread wait for us.
+            // and it's also beneficial so that the final mempool_cache.clear() does not delete tx we didn't use yet
+            let mut mempool_cache = state.mempool_cache.lock().await;
             let mut txs = vec![];
             for new_txid in new {
                 let tx = if let Some(tx) = mempool_cache.get(new_txid).cloned() {
@@ -75,8 +78,8 @@ async fn sync_mempool_once(
                 m.update(db, &removed, &txs);
                 mempool_txids.clear();
                 mempool_txids.extend(m.txids_iter());
-                mempool_cache.clear();
             }
+            mempool_cache.clear();
             let processing_time = start.elapsed();
             crate::MEMPOOL_LOOP_DURATION.set(processing_time.as_millis() as i64);
             Ok(MempoolSyncStats {
@@ -137,7 +140,6 @@ async fn mempool_sync(
     }
 
     let mut mempool_txids = HashSet::new();
-    let mut mempool_cache = HashMap::new();
     let support_vebose = client.mempool(true).await.is_ok();
     log::info!("mempool support verbose: {support_vebose}");
     let mut last_summary = Instant::now();
@@ -152,7 +154,7 @@ async fn mempool_sync(
             }
             _ = async {
                 if let Ok(stats) =
-                    sync_mempool_once(&client, support_vebose, &mut mempool_txids, &mut mempool_cache, &state, family)
+                    sync_mempool_once(&client, support_vebose, &mut mempool_txids, &state, family)
                         .await
                 {
                     processing_since_last_summary += stats.processing_time;

--- a/src/threads/mempool.rs
+++ b/src/threads/mempool.rs
@@ -1,5 +1,6 @@
 use crate::{
     be::Family,
+    cache_counter,
     fetch::Client,
     server::{Error, State},
     store::Store,
@@ -50,7 +51,9 @@ async fn sync_mempool_once(
             let mut mempool_cache = state.mempool_cache.lock().await;
             let mut txs = vec![];
             for new_txid in new {
-                let tx = if let Some(tx) = mempool_cache.get(new_txid).cloned() {
+                let cached_tx = mempool_cache.get(new_txid).cloned();
+                cache_counter("mempool_cache", cached_tx.is_some());
+                let tx = if let Some(tx) = cached_tx {
                     Ok(tx)
                 } else {
                     client.tx(*new_txid, family).await

--- a/src/threads/mempool.rs
+++ b/src/threads/mempool.rs
@@ -72,8 +72,7 @@ async fn sync_mempool_once(
             }
             {
                 let mut m = state.mempool.lock().await;
-                m.remove(&removed);
-                m.add(db, &txs);
+                m.update(db, &removed, &txs);
                 mempool_txids.clear();
                 mempool_txids.extend(m.txids_iter());
                 mempool_cache.clear();

--- a/src/threads/mod.rs
+++ b/src/threads/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod blocks;
 pub(crate) mod mempool;
+pub(crate) mod zmq;

--- a/src/threads/zmq.rs
+++ b/src/threads/zmq.rs
@@ -1,0 +1,77 @@
+use std::future::Future;
+
+use futures_util::StreamExt;
+use tmq::{subscribe, Context, Multipart};
+
+use crate::{be::Family, server::Error};
+
+pub(crate) async fn rawtx_listener_infallible(
+    endpoint: String,
+    family: Family,
+    shutdown_signal: impl Future<Output = ()>,
+) {
+    if let Err(e) = rawtx_listener(endpoint, family, shutdown_signal).await {
+        log::error!("{:?}", e);
+    }
+}
+
+async fn rawtx_listener(
+    endpoint: String,
+    family: Family,
+    shutdown_signal: impl Future<Output = ()>,
+) -> Result<(), Error> {
+    let ctx = Context::new();
+    let socket_builder = subscribe(&ctx)
+        .connect(&endpoint)
+        .map_err(|e| Error::String(format!("failed connecting ZMQ socket to {endpoint}: {e}")))?;
+    let mut socket = socket_builder
+        .subscribe(b"rawtx")
+        .map_err(|e| Error::String(format!("failed subscribing to rawtx on {endpoint}: {e}")))?;
+
+    log::info!("ZMQ rawtx thread listening on {endpoint}");
+
+    let mut signal = std::pin::pin!(shutdown_signal);
+
+    loop {
+        tokio::select! {
+            _ = &mut signal => {
+                log::info!("zmq rawtx thread received shutdown signal");
+                return Ok(());
+            }
+            message = socket.next() => {
+                match message {
+                    Some(Ok(message)) => process_rawtx_message(message, family)?,
+                    Some(Err(e)) => log::error!("error receiving ZMQ message from {endpoint}: {e}"),
+                    None => {
+                        return Err(Error::String(format!(
+                            "ZMQ socket closed unexpectedly for endpoint {endpoint}"
+                        )));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn process_rawtx_message(message: Multipart, family: Family) -> Result<(), Error> {
+    let mut parts = message.iter().map(|part| part.as_ref());
+    let Some(topic) = parts.next() else {
+        log::warn!("received ZMQ message without topic");
+        return Ok(());
+    };
+    let Some(payload) = parts.next() else {
+        log::warn!("received ZMQ message without payload for topic {:?}", topic);
+        return Ok(());
+    };
+
+    if topic != b"rawtx" {
+        log::debug!("ignoring ZMQ topic {:?}", topic);
+        return Ok(());
+    }
+
+    let tx = crate::be::Transaction::from_bytes(payload, family)
+        .map_err(|e| Error::String(format!("failed decoding rawtx payload from ZMQ: {e}")))?;
+    log::debug!("zmq rawtx txid={}", tx.txid());
+
+    Ok(())
+}

--- a/src/threads/zmq.rs
+++ b/src/threads/zmq.rs
@@ -81,6 +81,11 @@ async fn process_rawtx_message(
     let tx = crate::be::Transaction::from_bytes(payload, family)
         .map_err(|e| Error::String(format!("failed decoding rawtx payload from ZMQ: {e}")))?;
     let txid = tx.txid();
+    // Intentionally wait on the shared mempool_cache lock here. The mempool thread keeps
+    // it for the whole sync cycle so it can safely clear the cache at the end without
+    // racing with concurrent ZMQ inserts. We considered a small local queue here, but
+    // without a separate drain trigger/worker it could leave transactions sitting there
+    // until another ZMQ message arrives, so stalling on the lock is the simpler tradeoff.
     state.mempool_cache.lock().await.insert(txid, tx);
     log::debug!("zmq rawtx txid={txid}");
 

--- a/src/threads/zmq.rs
+++ b/src/threads/zmq.rs
@@ -1,21 +1,26 @@
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 use futures_util::StreamExt;
 use tmq::{subscribe, Context, Multipart};
 
-use crate::{be::Family, server::Error};
+use crate::{
+    be::Family,
+    server::{Error, State},
+};
 
 pub(crate) async fn rawtx_listener_infallible(
+    state: Arc<State>,
     endpoint: String,
     family: Family,
     shutdown_signal: impl Future<Output = ()>,
 ) {
-    if let Err(e) = rawtx_listener(endpoint, family, shutdown_signal).await {
+    if let Err(e) = rawtx_listener(state, endpoint, family, shutdown_signal).await {
         log::error!("{:?}", e);
     }
 }
 
 async fn rawtx_listener(
+    state: Arc<State>,
     endpoint: String,
     family: Family,
     shutdown_signal: impl Future<Output = ()>,
@@ -40,7 +45,7 @@ async fn rawtx_listener(
             }
             message = socket.next() => {
                 match message {
-                    Some(Ok(message)) => process_rawtx_message(message, family)?,
+                    Some(Ok(message)) => process_rawtx_message(&state, message, family).await?,
                     Some(Err(e)) => log::error!("error receiving ZMQ message from {endpoint}: {e}"),
                     None => {
                         return Err(Error::String(format!(
@@ -53,7 +58,11 @@ async fn rawtx_listener(
     }
 }
 
-fn process_rawtx_message(message: Multipart, family: Family) -> Result<(), Error> {
+async fn process_rawtx_message(
+    state: &Arc<State>,
+    message: Multipart,
+    family: Family,
+) -> Result<(), Error> {
     let mut parts = message.iter().map(|part| part.as_ref());
     let Some(topic) = parts.next() else {
         log::warn!("received ZMQ message without topic");
@@ -71,7 +80,9 @@ fn process_rawtx_message(message: Multipart, family: Family) -> Result<(), Error
 
     let tx = crate::be::Transaction::from_bytes(payload, family)
         .map_err(|e| Error::String(format!("failed decoding rawtx payload from ZMQ: {e}")))?;
-    log::debug!("zmq rawtx txid={}", tx.txid());
+    let txid = tx.txid();
+    state.mempool_cache.lock().await.insert(txid, tx);
+    log::debug!("zmq rawtx txid={txid}");
 
     Ok(())
 }

--- a/src/threads/zmq.rs
+++ b/src/threads/zmq.rs
@@ -1,4 +1,8 @@
-use std::{future::Future, sync::Arc};
+use std::{
+    future::Future,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use futures_util::StreamExt;
 use tmq::{subscribe, Context, Multipart};
@@ -25,6 +29,8 @@ async fn rawtx_listener(
     family: Family,
     shutdown_signal: impl Future<Output = ()>,
 ) -> Result<(), Error> {
+    let mut received_txs = 0u64;
+    let mut last_summary = Instant::now();
     let ctx = Context::new();
     let socket_builder = subscribe(&ctx)
         .connect(&endpoint)
@@ -45,7 +51,15 @@ async fn rawtx_listener(
             }
             message = socket.next() => {
                 match message {
-                    Some(Ok(message)) => process_rawtx_message(&state, message, family).await?,
+                    Some(Ok(message)) => {
+                        process_rawtx_message(&state, message, family).await?;
+                        received_txs += 1;
+                        if last_summary.elapsed() >= Duration::from_secs(5 * 60) {
+                            log::info!("zmq rawtx summary: received_txs={received_txs}");
+                            last_summary = Instant::now();
+                            received_txs = 0;
+                        }
+                    }
                     Some(Err(e)) => log::error!("error receiving ZMQ message from {endpoint}: {e}"),
                     None => {
                         return Err(Error::String(format!(


### PR DESCRIPTION
To improve mempool syncing time, we optionally pre-populate the transaction cache with a zmq thread. In the best case during the mempool sync no transaction is asked to the node, because the cache received those from zmq