### PR TITLE
Introduce light tx repr for cache. reducing mem req

### DIFF
--- a/src/be/mod.rs
+++ b/src/be/mod.rs
@@ -11,7 +11,7 @@ pub use block::Block;
 pub use block_header::BlockHeader;
 pub use descriptor::{bitcoin_descriptor, Descriptor};
 pub use outpoint::OutPoint;
-pub use transaction::{Input, InputRef, Output, OutputRef, Transaction, TransactionRef};
+pub use transaction::{Input, InputRef, MempoolTx, Output, OutputRef, Transaction, TransactionRef};
 pub use txid::Txid;
 
 use crate::server::Network;

--- a/src/be/transaction.rs
+++ b/src/be/transaction.rs
@@ -6,6 +6,12 @@ pub enum Transaction {
     Elements(elements::Transaction),
 }
 
+#[derive(Debug, Clone)]
+pub struct MempoolTx {
+    inputs: Vec<crate::OutPoint>,
+    output_script_hashes: Vec<crate::ScriptHash>,
+}
+
 #[derive(Debug)]
 pub enum TransactionRef<'a> {
     Bitcoin(&'a bitcoin::Transaction),
@@ -38,22 +44,6 @@ impl Transaction {
         match self {
             Transaction::Bitcoin(tx) => tx.compute_txid().into(),
             Transaction::Elements(tx) => tx.txid().into(),
-        }
-    }
-
-    /// Iterator over outputs without cloning - more efficient for indexing
-    pub(crate) fn outputs_iter(&self) -> impl Iterator<Item = be::OutputRef> {
-        match self {
-            Transaction::Bitcoin(tx) => OutputIterator::Bitcoin(tx.output.iter()),
-            Transaction::Elements(tx) => OutputIterator::Elements(tx.output.iter()),
-        }
-    }
-
-    /// Iterator over inputs without cloning - more efficient for indexing
-    pub(crate) fn inputs_iter(&self) -> impl Iterator<Item = be::InputRef> {
-        match self {
-            Transaction::Bitcoin(tx) => InputIterator::Bitcoin(tx.input.iter()),
-            Transaction::Elements(tx) => InputIterator::Elements(tx.input.iter()),
         }
     }
 
@@ -93,6 +83,37 @@ impl Transaction {
     pub(crate) fn from_str(tx_hex: &str, family: be::Family) -> Result<Self, anyhow::Error> {
         let bytes = hex_simd::decode_to_vec(tx_hex.as_bytes())?;
         Self::from_bytes(&bytes, family)
+    }
+}
+
+impl MempoolTx {
+    pub(crate) fn new(tx: &Transaction, script_hash: impl Fn(&[u8]) -> crate::ScriptHash) -> Self {
+        match tx {
+            Transaction::Bitcoin(tx) => MempoolTx {
+                inputs: tx.input.iter().map(|input| input.previous_output.into()).collect(),
+                output_script_hashes: tx
+                    .output
+                    .iter()
+                    .map(|output| script_hash(output.script_pubkey.as_bytes()))
+                    .collect(),
+            },
+            Transaction::Elements(tx) => MempoolTx {
+                inputs: tx.input.iter().map(|input| input.previous_output.into()).collect(),
+                output_script_hashes: tx
+                    .output
+                    .iter()
+                    .map(|output| script_hash(output.script_pubkey.as_bytes()))
+                    .collect(),
+            },
+        }
+    }
+
+    pub(crate) fn inputs_iter(&self) -> impl Iterator<Item = crate::OutPoint> + '_ {
+        self.inputs.iter().copied()
+    }
+
+    pub(crate) fn output_script_hashes_iter(&self) -> impl Iterator<Item = crate::ScriptHash> + '_ {
+        self.output_script_hashes.iter().copied()
     }
 }
 

--- a/src/server/mempool.rs
+++ b/src/server/mempool.rs
@@ -40,7 +40,7 @@ impl Mempool {
         &mut self,
         db: &AnyStore,
         removed_txids: &[crate::be::Txid],
-        txs: &[(crate::be::Txid, &be::Transaction)],
+        txs: &[(crate::be::Txid, &be::MempoolTx)],
     ) {
         self.remove(removed_txids);
         self.add(db, txs);
@@ -63,16 +63,15 @@ impl Mempool {
             .retain(|k, _| !txids.contains(&k.txid.into()));
     }
 
-    fn add(&mut self, db: &AnyStore, txs: &[(crate::be::Txid, &be::Transaction)]) {
+    fn add(&mut self, db: &AnyStore, txs: &[(crate::be::Txid, &be::MempoolTx)]) {
         // update the unconfirmed utxo set
         let outputs_created = txs
             .iter()
-            .flat_map(|(txid, tx)| tx.outputs_iter().enumerate().map(move |(vout, txout)| {
-                (
-                    OutPoint::new(*txid, vout as u32),
-                    db.hash(txout.script_pubkey_bytes()),
-                )
-            }));
+            .flat_map(|(txid, tx)| {
+                tx.output_script_hashes_iter()
+                    .enumerate()
+                    .map(move |(vout, script_hash)| (OutPoint::new(*txid, vout as u32), script_hash))
+            });
         self.outpoints_created.extend(outputs_created);
 
         // we need to build this map for every txid all the ScriptHash involved, for output is easy
@@ -86,17 +85,16 @@ impl Mempool {
         let prevouts: Vec<OutPoint> = txs
             .iter()
             .flat_map(|e| e.1.inputs_iter())
-            .map(|i| i.previous_output())
             .collect();
         let spending_script_hashes = db.get_utxos(&prevouts).unwrap();
 
         let mut prevouts_index = 0usize;
         for (txid, tx) in txs {
-            for (vin, input) in tx.inputs_iter().enumerate() {
+            for (vin, previous_output) in tx.inputs_iter().enumerate() {
                 let e = match spending_script_hashes[prevouts_index] {
                     Some(e) => e,
                     None => {
-                        match self.outpoints_created.get(&input.previous_output()) {
+                        match self.outpoints_created.get(&previous_output) {
                             Some(e) => *e,
                             None => {
                                 // in optimal condition should never happen, however, for example at startup we may have incomplete mempool data
@@ -116,8 +114,8 @@ impl Mempool {
                 prevouts_index += 1;
             }
 
-            for (vout, output) in tx.outputs_iter().enumerate() {
-                let e = db.hash(output.script_pubkey_bytes());
+            for (vout, script_hash) in tx.output_script_hashes_iter().enumerate() {
+                let e = script_hash;
                 txid_hashes.entry(*txid).or_default().insert(e);
                 // Positive position for outputs: vout + 1
                 txid_script_positions

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -28,7 +28,7 @@ pub struct State {
 
     pub store: AnyStore,
     pub mempool: Mutex<Mempool>,
-    pub mempool_cache: Mutex<HashMap<crate::be::Txid, crate::be::Transaction>>,
+    pub mempool_cache: Mutex<HashMap<crate::be::Txid, crate::be::MempoolTx>>,
     pub blocks_hash_ts: Mutex<Vec<(BlockHash, Timestamp)>>, // TODO should be moved into the Store, but in memory for db
 
     pub secp: Secp256k1<All>,

--- a/src/threads/mempool.rs
+++ b/src/threads/mempool.rs
@@ -81,7 +81,10 @@ async fn sync_mempool_once(
                 let tx = if let Some(tx) = cached_tx {
                     Ok(tx)
                 } else {
-                    client.tx(*new_txid, family).await
+                    client
+                        .tx(*new_txid, family)
+                        .await
+                        .map(|tx| crate::be::MempoolTx::new(&tx, |script| state.store.hash(script)))
                 };
                 match tx {
                     Ok(tx) => {

--- a/src/threads/zmq.rs
+++ b/src/threads/zmq.rs
@@ -10,6 +10,7 @@ use tmq::{subscribe, Context, Multipart};
 use crate::{
     be::Family,
     server::{Error, State},
+    store::Store,
 };
 
 pub(crate) async fn rawtx_listener_infallible(
@@ -95,12 +96,13 @@ async fn process_rawtx_message(
     let tx = crate::be::Transaction::from_bytes(payload, family)
         .map_err(|e| Error::String(format!("failed decoding rawtx payload from ZMQ: {e}")))?;
     let txid = tx.txid();
+    let mempool_tx = crate::be::MempoolTx::new(&tx, |script| state.store.hash(script));
     // Intentionally wait on the shared mempool_cache lock here. The mempool thread keeps
     // it for the whole sync cycle so it can safely clear the cache at the end without
     // racing with concurrent ZMQ inserts. We considered a small local queue here, but
     // without a separate drain trigger/worker it could leave transactions sitting there
     // until another ZMQ message arrives, so stalling on the lock is the simpler tradeoff.
-    state.mempool_cache.lock().await.insert(txid, tx);
+    state.mempool_cache.lock().await.insert(txid, mempool_tx);
     log::debug!("zmq rawtx txid={txid}");
 
     Ok(())


### PR DESCRIPTION
At process startup there is a peak memory usage for big mempool delta update. This change creates a light tx representation to be used in the cache, so that everything needed to update the Mempool state is there, but most of the Transaction data is pruned 