### PR TITLE
Subscribe

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -204,9 +204,11 @@ data: {"reason":"mempool"}
 
 **Event Reasons:**
 
-- `mempool`: a watched script appeared in a mempool transaction or changed mempool state
+- `mempool`: a watched script appeared in a newly observed mempool transaction
 - `block`: a watched script appeared in a newly indexed block
 - `reorg`: a chain reorganization happened; clients should rescan because affected scripts are not filtered precisely
+
+Mempool removals do not emit `mempool` events. In the common confirmation path, the server emits `mempool` when the transaction first appears and `block` after the confirming block is indexed.
 
 **Client Behavior:**
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -162,6 +162,58 @@ This endpoint is optimized for applications that only need to know the next unus
 
 To get the next unused external address, use index `external + 1` (or index `0` if `external` is null).
 
+### Descriptor Subscription
+```
+GET /v1/subscribe?descriptor=<descriptor>
+```
+
+Opens a Server-Sent Events (SSE) stream that notifies the client when a previously scanned descriptor may have new activity. The notification is only a hint; clients should perform the normal Waterfalls scan after receiving an event.
+
+**Query Parameters:**
+
+- `descriptor` (string, required): Bitcoin/Elements descriptor (plain text or encrypted with server key)
+  - Supports encryption using age encryption with server's public key
+  - Network validation: mainnet descriptors (xpub) cannot be used on testnet/regtest
+  - Must have a wildcard
+
+**Precondition:**
+
+- The descriptor must have been scanned with `/v1/waterfalls`, `/v2/waterfalls`, or `/v4/waterfalls` before subscribing
+- If the descriptor has never been scanned, the server returns `400 DescriptorNotScanned`
+- The server tracks the highest used derivation index observed during scans
+- Subscriptions watch scripts up to `max_used_index + GAP_LIMIT`; if a descriptor was scanned but has no used index yet, the initial gap window is watched
+
+**Response:**
+
+- Status: `200 OK`
+- Content-Type: `text/event-stream`
+- The stream starts with a comment event:
+
+```text
+: ready
+
+```
+
+When activity is detected for a watched script, the server sends:
+
+```text
+event: changed
+data: {"reason":"mempool"}
+
+```
+
+**Event Reasons:**
+
+- `mempool`: a watched script appeared in a mempool transaction or changed mempool state
+- `block`: a watched script appeared in a newly indexed block
+- `reorg`: a chain reorganization happened; clients should rescan because affected scripts are not filtered precisely
+
+**Client Behavior:**
+
+- Treat events as invalidation hints, not as wallet updates
+- On any `changed` event, run the usual Waterfalls scan to obtain authoritative history and tip state
+- On reconnect, run a Waterfalls scan before relying on subscription events, because events may have been missed while disconnected
+
 ## Base Endpoints
 
 ### Server Information

--- a/docs/API.md
+++ b/docs/API.md
@@ -210,6 +210,11 @@ data: {"reason":"mempool"}
 
 Mempool removals do not emit `mempool` events. In the common confirmation path, the server emits `mempool` when the transaction first appears and `block` after the confirming block is indexed.
 
+**Limitations:**
+
+- At the moment active subscriptions do not expand when later scans increase the descriptor's highest used index
+- To watch the expanded range, clients should close the current SSE stream and re-open a new subscription
+
 **Client Behavior:**
 
 - Treat events as invalidation hints, not as wallet updates

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@ type ScriptHash = u64;
 type Height = u32;
 type Timestamp = u32;
 
-const DESCRIPTOR_MAX_DERIVED_INDEX_BUCKETS: &[u32] = &[
+const DESCRIPTOR_MAX_USED_INDEX_BUCKETS: &[u32] = &[
     20, 40, 60, 80, 100, 120, 140, 160, 180, 200, 400, 800, 1600, 3200, 6400, 12800,
 ];
-const DESCRIPTOR_MAX_DERIVED_INDEX_BUCKET_LABEL_WIDTH: usize = 5;
+const DESCRIPTOR_MAX_USED_INDEX_BUCKET_LABEL_WIDTH: usize = 5;
 
 /// Request to the waterfalls endpoint
 #[derive(Debug)]
@@ -360,10 +360,10 @@ lazy_static! {
         "Unique descriptor IDs seen within the last 24 hours."
     )
     .unwrap();
-    static ref WATERFALLS_DESCRIPTOR_MAX_DERIVED_INDEX_DESCRIPTORS: IntGaugeVec =
+    static ref WATERFALLS_DESCRIPTOR_MAX_USED_INDEX_DESCRIPTORS: IntGaugeVec =
         register_int_gauge_vec!(
-            "waterfalls_descriptor_max_derived_index_descriptors",
-            "Number of descriptors grouped by their max derived index bucket. Bucket labels are zero-padded so lexicographic order matches numeric order.",
+            "waterfalls_descriptor_max_used_index_descriptors",
+            "Number of descriptors grouped by their max used index bucket. Bucket labels are zero-padded so lexicographic order matches numeric order.",
             &["range"]
         )
         .unwrap();
@@ -386,60 +386,60 @@ pub(crate) fn set_unique_descriptors(count: usize) {
     crate::WATERFALLS_UNIQUE_DESCRIPTORS.set(count as i64);
 }
 
-pub(crate) fn set_descriptor_max_derived_index_buckets<I>(max_indexes: I)
+pub(crate) fn set_descriptor_max_used_index_buckets<I>(max_indexes: I)
 where
     I: IntoIterator<Item = u32>,
 {
     let mut counts = BTreeMap::new();
     for index in max_indexes {
         *counts
-            .entry(descriptor_max_derived_index_bucket_label(index))
+            .entry(descriptor_max_used_index_bucket_label(index))
             .or_insert(0) += 1;
     }
 
     let mut lower = 0;
-    for upper in DESCRIPTOR_MAX_DERIVED_INDEX_BUCKETS {
-        let label = descriptor_max_derived_index_bucket_range_label(lower, *upper);
+    for upper in DESCRIPTOR_MAX_USED_INDEX_BUCKETS {
+        let label = descriptor_max_used_index_bucket_range_label(lower, *upper);
         let count = counts.get(label.as_str()).copied().unwrap_or(0);
-        crate::WATERFALLS_DESCRIPTOR_MAX_DERIVED_INDEX_DESCRIPTORS
+        crate::WATERFALLS_DESCRIPTOR_MAX_USED_INDEX_DESCRIPTORS
             .with_label_values(&[&label])
             .set(count);
         lower = *upper;
     }
 
-    let overflow_label = descriptor_max_derived_index_bucket_overflow_label();
+    let overflow_label = descriptor_max_used_index_bucket_overflow_label();
     let overflow_count = counts.get(overflow_label.as_str()).copied().unwrap_or(0);
-    crate::WATERFALLS_DESCRIPTOR_MAX_DERIVED_INDEX_DESCRIPTORS
+    crate::WATERFALLS_DESCRIPTOR_MAX_USED_INDEX_DESCRIPTORS
         .with_label_values(&[&overflow_label])
         .set(overflow_count);
 }
 
-fn descriptor_max_derived_index_bucket_label(index: u32) -> String {
+fn descriptor_max_used_index_bucket_label(index: u32) -> String {
     let mut lower = 0;
-    for upper in DESCRIPTOR_MAX_DERIVED_INDEX_BUCKETS {
+    for upper in DESCRIPTOR_MAX_USED_INDEX_BUCKETS {
         if index <= *upper {
-            return descriptor_max_derived_index_bucket_range_label(lower, *upper);
+            return descriptor_max_used_index_bucket_range_label(lower, *upper);
         }
         lower = *upper;
     }
 
-    descriptor_max_derived_index_bucket_overflow_label()
+    descriptor_max_used_index_bucket_overflow_label()
 }
 
-fn descriptor_max_derived_index_bucket_range_label(lower: u32, upper: u32) -> String {
+fn descriptor_max_used_index_bucket_range_label(lower: u32, upper: u32) -> String {
     format!(
         "{lower:0width$}-{upper:0width$}",
-        width = DESCRIPTOR_MAX_DERIVED_INDEX_BUCKET_LABEL_WIDTH
+        width = DESCRIPTOR_MAX_USED_INDEX_BUCKET_LABEL_WIDTH
     )
 }
 
-fn descriptor_max_derived_index_bucket_overflow_label() -> String {
+fn descriptor_max_used_index_bucket_overflow_label() -> String {
     format!(
         "{:0width$}+",
-        DESCRIPTOR_MAX_DERIVED_INDEX_BUCKETS
+        DESCRIPTOR_MAX_USED_INDEX_BUCKETS
             .last()
             .expect("at least one bucket"),
-        width = DESCRIPTOR_MAX_DERIVED_INDEX_BUCKET_LABEL_WIDTH
+        width = DESCRIPTOR_MAX_USED_INDEX_BUCKET_LABEL_WIDTH
     )
 }
 
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn test_descriptor_metrics_registered() {
         set_unique_descriptors(7);
-        set_descriptor_max_derived_index_buckets([20, 30, 40, 1001]);
+        set_descriptor_max_used_index_buckets([20, 30, 40, 1001]);
 
         let metric_names = prometheus::gather()
             .into_iter()
@@ -546,38 +546,24 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(metric_names.contains(&"waterfalls_unique_descriptors".to_string()));
-        assert!(metric_names
-            .contains(&"waterfalls_descriptor_max_derived_index_descriptors".to_string()));
+        assert!(
+            metric_names.contains(&"waterfalls_descriptor_max_used_index_descriptors".to_string())
+        );
     }
 
     #[test]
-    fn test_descriptor_max_derived_index_bucket_label() {
-        assert_eq!(descriptor_max_derived_index_bucket_label(0), "00000-00020");
-        assert_eq!(descriptor_max_derived_index_bucket_label(1), "00000-00020");
-        assert_eq!(descriptor_max_derived_index_bucket_label(20), "00000-00020");
-        assert_eq!(descriptor_max_derived_index_bucket_label(21), "00020-00040");
-        assert_eq!(descriptor_max_derived_index_bucket_label(40), "00020-00040");
-        assert_eq!(descriptor_max_derived_index_bucket_label(41), "00040-00060");
-        assert_eq!(
-            descriptor_max_derived_index_bucket_label(200),
-            "00180-00200"
-        );
-        assert_eq!(
-            descriptor_max_derived_index_bucket_label(201),
-            "00200-00400"
-        );
-        assert_eq!(
-            descriptor_max_derived_index_bucket_label(400),
-            "00200-00400"
-        );
-        assert_eq!(
-            descriptor_max_derived_index_bucket_label(401),
-            "00400-00800"
-        );
-        assert_eq!(
-            descriptor_max_derived_index_bucket_label(12800),
-            "06400-12800"
-        );
-        assert_eq!(descriptor_max_derived_index_bucket_label(12801), "12800+");
+    fn test_descriptor_max_used_index_bucket_label() {
+        assert_eq!(descriptor_max_used_index_bucket_label(0), "00000-00020");
+        assert_eq!(descriptor_max_used_index_bucket_label(1), "00000-00020");
+        assert_eq!(descriptor_max_used_index_bucket_label(20), "00000-00020");
+        assert_eq!(descriptor_max_used_index_bucket_label(21), "00020-00040");
+        assert_eq!(descriptor_max_used_index_bucket_label(40), "00020-00040");
+        assert_eq!(descriptor_max_used_index_bucket_label(41), "00040-00060");
+        assert_eq!(descriptor_max_used_index_bucket_label(200), "00180-00200");
+        assert_eq!(descriptor_max_used_index_bucket_label(201), "00200-00400");
+        assert_eq!(descriptor_max_used_index_bucket_label(400), "00200-00400");
+        assert_eq!(descriptor_max_used_index_bucket_label(401), "00400-00800");
+        assert_eq!(descriptor_max_used_index_bucket_label(12800), "06400-12800");
+        assert_eq!(descriptor_max_used_index_bucket_label(12801), "12800+");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,6 +355,13 @@ lazy_static! {
         &["kind"]
     )
     .unwrap();
+    static ref WATERFALLS_SUBSCRIPTION_NOTIFICATIONS_COUNTER: IntCounterVec =
+        register_int_counter_vec!(
+            "waterfalls_subscription_notifications_total",
+            "Subscription notifications by event type and delivery result.",
+            &["event", "result"]
+        )
+        .unwrap();
     pub(crate) static ref WATERFALLS_UNIQUE_DESCRIPTORS: IntGauge = register_int_gauge!(
         "waterfalls_unique_descriptors",
         "Unique descriptor IDs seen within the last 24 hours."
@@ -379,6 +386,12 @@ pub(crate) fn cache_counter(cache_name: &str, hit_miss: bool) {
 pub(crate) fn inc_connection_error_counter(kind: &str) {
     crate::WATERFALLS_CONNECTION_ERROR_COUNTER
         .with_label_values(&[kind])
+        .inc();
+}
+
+pub(crate) fn inc_subscription_notification_counter(event: &str, result: &str) {
+    crate::WATERFALLS_SUBSCRIPTION_NOTIFICATIONS_COUNTER
+        .with_label_values(&[event, result])
         .inc();
 }
 
@@ -536,9 +549,10 @@ mod tests {
     }
 
     #[test]
-    fn test_descriptor_metrics_registered() {
+    fn test_metrics_registered() {
         set_unique_descriptors(7);
         set_descriptor_max_used_index_buckets([20, 30, 40, 1001]);
+        inc_subscription_notification_counter("mempool", "queued");
 
         let metric_names = prometheus::gather()
             .into_iter()
@@ -549,6 +563,7 @@ mod tests {
         assert!(
             metric_names.contains(&"waterfalls_descriptor_max_used_index_descriptors".to_string())
         );
+        assert!(metric_names.contains(&"waterfalls_subscription_notifications_total".to_string()));
     }
 
     #[test]

--- a/src/server/mempool.rs
+++ b/src/server/mempool.rs
@@ -39,15 +39,18 @@ impl Mempool {
         db: &AnyStore,
         removed_txids: &[crate::be::Txid],
         txs: &[(crate::be::Txid, &be::MempoolTx)],
-    ) {
-        self.remove(removed_txids);
-        self.add(db, txs);
+    ) -> HashSet<ScriptHash> {
+        let mut changed = self.remove(removed_txids);
+        changed.extend(self.add(db, txs));
+        changed
     }
 
-    fn remove(&mut self, txids: &[crate::be::Txid]) {
+    fn remove(&mut self, txids: &[crate::be::Txid]) -> HashSet<ScriptHash> {
+        let mut changed = HashSet::new();
         for txid in txids {
             if let Some(hashes) = self.txid_hashes.remove(txid) {
                 for hash in hashes {
+                    changed.insert(hash);
                     if let Some(txid_positions) = self.hash_txids.get_mut(&hash) {
                         txid_positions.retain(|(tx, _)| tx != txid);
                         if txid_positions.is_empty() {
@@ -59,9 +62,14 @@ impl Mempool {
         }
         self.outpoints_created
             .retain(|k, _| !txids.contains(&k.txid.into()));
+        changed
     }
 
-    fn add(&mut self, db: &AnyStore, txs: &[(crate::be::Txid, &be::MempoolTx)]) {
+    fn add(
+        &mut self,
+        db: &AnyStore,
+        txs: &[(crate::be::Txid, &be::MempoolTx)],
+    ) -> HashSet<ScriptHash> {
         // update the unconfirmed utxo set
         let outputs_created = txs.iter().flat_map(|(txid, tx)| {
             tx.output_script_hashes_iter()
@@ -118,7 +126,9 @@ impl Mempool {
             }
         }
 
+        let mut changed = HashSet::new();
         for (k, v) in txid_hashes {
+            changed.extend(v.iter().copied());
             self.txid_hashes.entry(k).or_default().extend(&v);
         }
 
@@ -131,6 +141,8 @@ impl Mempool {
                     .push((txid, position));
             }
         }
+
+        changed
     }
 
     pub fn append_seen(&self, script_hashes: &[ScriptHash], out: &mut [Vec<TxSeen>]) {

--- a/src/server/mempool.rs
+++ b/src/server/mempool.rs
@@ -40,17 +40,14 @@ impl Mempool {
         removed_txids: &[crate::be::Txid],
         txs: &[(crate::be::Txid, &be::MempoolTx)],
     ) -> HashSet<ScriptHash> {
-        let mut changed = self.remove(removed_txids);
-        changed.extend(self.add(db, txs));
-        changed
+        self.remove(removed_txids);
+        self.add(db, txs)
     }
 
-    fn remove(&mut self, txids: &[crate::be::Txid]) -> HashSet<ScriptHash> {
-        let mut changed = HashSet::new();
+    fn remove(&mut self, txids: &[crate::be::Txid]) {
         for txid in txids {
             if let Some(hashes) = self.txid_hashes.remove(txid) {
                 for hash in hashes {
-                    changed.insert(hash);
                     if let Some(txid_positions) = self.hash_txids.get_mut(&hash) {
                         txid_positions.retain(|(tx, _)| tx != txid);
                         if txid_positions.is_empty() {
@@ -62,7 +59,6 @@ impl Mempool {
         }
         self.outpoints_created
             .retain(|k, _| !txids.contains(&k.txid.into()));
-        changed
     }
 
     fn add(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -322,6 +322,7 @@ pub enum Error {
     TooManyAddresses,
     AddressPageRequiresSingleAddress,
     DescriptorMustHaveWildcard,
+    DescriptorNotScanned,
     UtxoOnlyHistoryTooLarge,
     BodyTooLarge,
     BodyReadTimeout,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -30,9 +30,11 @@ pub mod preload;
 pub mod route;
 pub mod sign;
 mod state;
+mod subscription;
 
 pub use mempool::Mempool;
 pub use state::State;
+pub(crate) use subscription::SubscriptionEvent;
 
 const DEFAULT_MAX_TXS_SEEN: usize = 100;
 const PERIODIC_LOGGING_INTERVAL: Duration = Duration::from_secs(300);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -590,14 +590,13 @@ async fn periodic_logging(state: Arc<State>, shutdown_signal: impl Future<Output
 }
 
 async fn log_periodic_state(state: &State) {
-    let descriptor_max_derived_index = state.descriptor_max_derived_index_snapshot().await;
-    if !descriptor_max_derived_index.is_empty() {
-        let descriptor_max_derived_index: std::collections::BTreeMap<_, _> =
-            descriptor_max_derived_index
-                .into_iter()
-                .map(|(id, index)| (format!("{id:x}"), index))
-                .collect();
-        log::info!("descriptor max derived indexes: {descriptor_max_derived_index:?}");
+    let descriptor_max_used_index = state.descriptor_max_used_index_snapshot().await;
+    if !descriptor_max_used_index.is_empty() {
+        let descriptor_max_used_index: std::collections::BTreeMap<_, _> = descriptor_max_used_index
+            .into_iter()
+            .map(|(id, index)| (format!("{id:x}"), index))
+            .collect();
+        log::info!("descriptor max used indexes: {descriptor_max_used_index:?}");
     }
 }
 

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -641,10 +641,11 @@ async fn handle_waterfalls_req(
                     let batch_start = batch * GAP_LIMIT + page as u32 * MAX_ADDRESSES;
                     let (scripts, batch_derivations_duration) =
                         derive_script_hashes_batch(state, desc, batch_start, GAP_LIMIT).await;
+                    let max_derived_index = batch_start + scripts.len() as u32 - 1;
                     state
                         .record_descriptor_max_derived_index(
                             single_descriptor_id,
-                            batch_start + GAP_LIMIT,
+                            max_derived_index,
                         )
                         .await;
                     derivations_duration += batch_derivations_duration;

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -232,7 +232,7 @@ pub async fn route(
         (&Method::GET, "/metrics", None) => {
             let encoder = prometheus::TextEncoder::new();
 
-            state.update_descriptor_max_derived_index_metrics().await;
+            state.update_descriptor_max_used_index_metrics().await;
             let metric_families = prometheus::gather();
             let mut buffer = vec![];
             encoder
@@ -675,16 +675,15 @@ async fn handle_waterfalls_req(
                     let batch_start = batch * GAP_LIMIT + page as u32 * MAX_ADDRESSES;
                     let (scripts, batch_derivations_duration) =
                         derive_script_hashes_batch(state, desc, batch_start, GAP_LIMIT).await;
-                    let max_derived_index = batch_start + scripts.len() as u32 - 1;
-                    state
-                        .record_descriptor_max_derived_index(
-                            single_descriptor_id,
-                            max_derived_index,
-                        )
-                        .await;
                     derivations_duration += batch_derivations_duration;
 
                     let find_result = find_scripts(state, db, &mut result, scripts, 0, true).await;
+                    let max_used_index = find_result
+                        .max_used_offset
+                        .map(|offset| batch_start + offset);
+                    state
+                        .record_descriptor_scan_max_used_index(single_descriptor_id, max_used_index)
+                        .await;
                     if utxo_only && find_result.has_more.iter().any(|has_more| *has_more) {
                         return Err(Error::UtxoOnlyHistoryTooLarge);
                     }
@@ -967,11 +966,11 @@ async fn subscribe_descriptor(
     let mut scripts = Vec::new();
     for desc in descriptor.into_single_descriptors().unwrap().iter() {
         let single_descriptor_id = string_hash(&desc.to_string());
-        let max_derived_index = state
-            .descriptor_max_derived_index(single_descriptor_id)
+        let max_used_index = state
+            .descriptor_max_used_index(single_descriptor_id)
             .await
             .ok_or(Error::DescriptorNotScanned)?;
-        let watch_count = subscription_watch_count(max_derived_index)?;
+        let watch_count = subscription_watch_count(max_used_index)?;
         scripts.extend(
             derive_script_hashes_batch(state, desc, 0, watch_count)
                 .await
@@ -1043,11 +1042,14 @@ fn subscription_event_reason(event: SubscriptionEvent) -> &'static str {
     }
 }
 
-fn subscription_watch_count(max_derived_index: u32) -> Result<u32, Error> {
-    max_derived_index
-        .checked_add(GAP_LIMIT)
-        .and_then(|max_watch_index| max_watch_index.checked_add(1))
-        .ok_or_else(|| Error::String("subscription derivation range overflow".to_string()))
+fn subscription_watch_count(max_used_index: Option<u32>) -> Result<u32, Error> {
+    match max_used_index {
+        Some(max_used_index) => max_used_index
+            .checked_add(GAP_LIMIT)
+            .and_then(|max_watch_index| max_watch_index.checked_add(1))
+            .ok_or_else(|| Error::String("subscription derivation range overflow".to_string())),
+        None => Ok(GAP_LIMIT),
+    }
 }
 
 async fn find_scripts(
@@ -1071,9 +1073,24 @@ async fn find_scripts(
             .await
             .append_seen(&scripts, &mut seen_blockchain);
     }
+    let max_used_offset = seen_blockchain
+        .iter()
+        .enumerate()
+        .filter_map(|(index, txs_seen)| {
+            if txs_seen.is_empty() {
+                None
+            } else {
+                Some(index as u32)
+            }
+        })
+        .max();
     let is_last = seen_blockchain.iter().all(|e| e.is_empty());
     result.extend(seen_blockchain);
-    FindScriptsResult { is_last, has_more }
+    FindScriptsResult {
+        is_last,
+        has_more,
+        max_used_offset,
+    }
 }
 
 fn truncate_history_page(
@@ -1099,6 +1116,7 @@ fn truncate_history_page(
 struct FindScriptsResult {
     is_last: bool,
     has_more: Vec<bool>,
+    max_used_offset: Option<u32>,
 }
 
 fn calculate_script_pubkey_with_timing(
@@ -1379,13 +1397,14 @@ mod tests {
 
     #[test]
     fn test_subscription_watch_count() {
-        assert_eq!(subscription_watch_count(0).unwrap(), GAP_LIMIT + 1);
+        assert_eq!(subscription_watch_count(None).unwrap(), GAP_LIMIT);
+        assert_eq!(subscription_watch_count(Some(0)).unwrap(), GAP_LIMIT + 1);
         assert_eq!(
-            subscription_watch_count(GAP_LIMIT).unwrap(),
+            subscription_watch_count(Some(GAP_LIMIT)).unwrap(),
             GAP_LIMIT * 2 + 1
         );
-        assert!(subscription_watch_count(u32::MAX).is_err());
-        assert!(subscription_watch_count(u32::MAX - GAP_LIMIT).is_err());
+        assert!(subscription_watch_count(Some(u32::MAX)).is_err());
+        assert!(subscription_watch_count(Some(u32::MAX - GAP_LIMIT)).is_err());
     }
 
     #[test]

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -9,9 +9,10 @@ use crate::{
 use age::x25519::Identity;
 use base64::prelude::{Engine, BASE64_STANDARD_NO_PAD};
 use elements::BlockHash;
-use http_body_util::{BodyExt, Full, Limited};
+use futures_util::{stream, StreamExt};
+use http_body_util::{combinators::BoxBody, BodyExt, Full, Limited, StreamBody};
 use hyper::{
-    body::{Bytes, Incoming},
+    body::{Bytes, Frame, Incoming},
     header::{self, CACHE_CONTROL, CONTENT_TYPE},
     Method, Request, Response, StatusCode,
 };
@@ -19,6 +20,7 @@ use prometheus::Encoder;
 use serde::Serialize;
 use std::{
     collections::{BTreeMap, HashSet},
+    convert::Infallible,
     hash::{DefaultHasher, Hash, Hasher},
     str::FromStr,
     sync::Arc,
@@ -29,7 +31,7 @@ use tokio::sync::Mutex;
 use super::{
     encryption,
     sign::MsgSigAddress,
-    subscription::{SubscriptionId, SubscriptionReceiver},
+    subscription::{SubscriptionEvent, SubscriptionId, SubscriptionReceiver},
     Network,
 };
 
@@ -53,6 +55,9 @@ const MAX_TX_BODY_SIZE: usize = 1024 * 1024; // 1MB limit for transaction broadc
 const BODY_READ_TIMEOUT: Duration = Duration::from_secs(30); // timeout for reading request body
 const FEE_ESTIMATES_TTL: u32 = 30; // cache fee estimates for 30 seconds
 
+type RespBody = BoxBody<Bytes, Infallible>;
+type Resp = Response<RespBody>;
+
 // needed endpoint to make this self-contained for testing, in prod they should probably be never hit cause proxied by nginx
 // https://waterfalls.liquidwebwallet.org/liquidtestnet/api/blocks/tip/hash
 // https://waterfalls.liquidwebwallet.org/liquidtestnet/api/block/bddf520b05c7552dca87289a035043a5c434133b3d1bb07b255fb1a30592b2d4/header
@@ -63,7 +68,7 @@ pub async fn route(
     client: &Arc<Mutex<Client>>,
     req: Request<Incoming>,
     network: Network,
-) -> Result<Response<Full<Bytes>>, Error> {
+) -> Result<Resp, Error> {
     let is_testnet_or_regtest = !matches!(network, Network::Liquid | Network::Bitcoin);
     log::debug!("---> {req:?}");
     let res = match (req.method(), req.uri().path(), req.uri().query()) {
@@ -143,6 +148,11 @@ pub async fn route(
             let descriptor =
                 parse_descriptor_query(query, &state.key, is_testnet_or_regtest, network)?;
             handle_last_used_index(state, descriptor).await
+        }
+        (&Method::GET, "/v1/subscribe", Some(query)) => {
+            let descriptor =
+                parse_descriptor_query(query, &state.key, is_testnet_or_regtest, network)?;
+            handle_subscribe_req(state, descriptor).await
         }
         (&Method::GET, "/v1/time_since_last_block", None) => {
             // this method return the seconds since last block
@@ -375,9 +385,7 @@ pub async fn route(
     res
 }
 
-fn block_hash_resp(
-    block_hash: Option<elements::BlockHash>,
-) -> Result<Response<Full<Bytes>>, Error> {
+fn block_hash_resp(block_hash: Option<elements::BlockHash>) -> Result<Resp, Error> {
     match block_hash {
         Some(h) => str_resp(h.to_string(), StatusCode::OK),
         None => str_resp("cannot find it".to_string(), StatusCode::NOT_FOUND),
@@ -493,7 +501,7 @@ fn parse_descriptor_query(
     Ok(descriptor)
 }
 
-fn str_resp(s: String, status: StatusCode) -> Result<Response<Full<Bytes>>, Error> {
+fn str_resp(s: String, status: StatusCode) -> Result<Resp, Error> {
     any_resp(s.into_bytes(), status, Some("text/plain"), None, None)
 }
 fn any_resp(
@@ -502,7 +510,7 @@ fn any_resp(
     content: Option<&str>,
     cache: Option<u32>,
     msg_sig_adr: Option<MsgSigAddress>,
-) -> Result<Response<Full<Bytes>>, Error> {
+) -> Result<Resp, Error> {
     let mut builder = Response::builder().status(status);
     if let Some(content) = content {
         builder = builder.header(CONTENT_TYPE, content)
@@ -521,15 +529,36 @@ fn any_resp(
         builder = builder.header("X-Server-Address", msg_sig_adr.address.to_string());
     }
 
-    builder
-        .body(Full::new(bytes.into()))
-        .map_err(|_| Error::Other)
+    builder.body(full_body(bytes)).map_err(|_| Error::Other)
 }
 
-async fn handle_single_address(
-    state: &Arc<State>,
-    address: &be::Address,
-) -> Result<Response<Full<Bytes>>, Error> {
+fn full_body(bytes: Vec<u8>) -> RespBody {
+    Full::new(Bytes::from(bytes))
+        .map_err(|never| match never {})
+        .boxed()
+}
+
+fn error_resp(status: StatusCode, error: &Error) -> Resp {
+    Response::builder()
+        .status(status)
+        .body(full_body(error.to_string().into_bytes()))
+        .unwrap()
+}
+
+fn error_status(error: &Error) -> StatusCode {
+    match error {
+        Error::CannotDecrypt => StatusCode::UNPROCESSABLE_ENTITY,
+        Error::DescriptorMustHaveWildcard
+        | Error::AddressPageRequiresSingleAddress
+        | Error::UtxoOnlyHistoryTooLarge
+        | Error::DescriptorNotScanned => StatusCode::BAD_REQUEST,
+        Error::BodyTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+        Error::BodyReadTimeout => StatusCode::REQUEST_TIMEOUT,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+async fn handle_single_address(state: &Arc<State>, address: &be::Address) -> Result<Resp, Error> {
     #[derive(Serialize)]
     struct EsploraTx {
         txid: crate::be::Txid,
@@ -609,7 +638,7 @@ async fn handle_waterfalls_req(
     with_tip: WithTip,
     cbor: bool,
     network: Network,
-) -> Result<Response<Full<Bytes>>, Error> {
+) -> Result<Resp, Error> {
     let db = &state.store;
     let start = Instant::now();
     let page = inputs.page();
@@ -810,7 +839,7 @@ async fn handle_waterfalls_req(
 async fn handle_last_used_index(
     state: &Arc<State>,
     descriptor: be::Descriptor,
-) -> Result<Response<Full<Bytes>>, Error> {
+) -> Result<Resp, Error> {
     let db = &state.store;
     let start = Instant::now();
     let id = string_hash(&descriptor.to_string());
@@ -923,7 +952,14 @@ fn filter_utxo_only(result: &mut [Vec<TxSeen>], db: &crate::store::AnyStore) -> 
     Ok(())
 }
 
-#[allow(dead_code)]
+async fn handle_subscribe_req(
+    state: &Arc<State>,
+    descriptor: be::Descriptor,
+) -> Result<Resp, Error> {
+    let (id, receiver) = subscribe_descriptor(state, descriptor).await?;
+    sse_resp(state.clone(), id, receiver)
+}
+
 async fn subscribe_descriptor(
     state: &Arc<State>,
     descriptor: be::Descriptor,
@@ -947,6 +983,64 @@ async fn subscribe_descriptor(
         .subscribe_scripts(scripts)
         .await
         .map_err(|e| Error::String(format!("{e:?}")))
+}
+
+fn sse_resp(
+    state: Arc<State>,
+    id: SubscriptionId,
+    receiver: SubscriptionReceiver,
+) -> Result<Resp, Error> {
+    let cleanup = SubscriptionCleanup { state, id };
+    let ready = stream::once(async {
+        Ok::<Frame<Bytes>, Infallible>(Frame::data(Bytes::from_static(b": ready\n\n")))
+    });
+    let events = stream::unfold((receiver, cleanup), |(mut receiver, cleanup)| async move {
+        receiver.recv().await.map(|event| {
+            (
+                Ok::<Frame<Bytes>, Infallible>(Frame::data(Bytes::from(sse_event(event)))),
+                (receiver, cleanup),
+            )
+        })
+    });
+    let body = BodyExt::boxed(StreamBody::new(ready.chain(events)));
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "text/event-stream")
+        .header(CACHE_CONTROL, "no-cache")
+        .header("X-Accel-Buffering", "no")
+        .body(body)
+        .map_err(|_| Error::Other)
+}
+
+struct SubscriptionCleanup {
+    state: Arc<State>,
+    id: SubscriptionId,
+}
+
+impl Drop for SubscriptionCleanup {
+    fn drop(&mut self) {
+        let state = self.state.clone();
+        let id = self.id;
+        tokio::spawn(async move {
+            state.unsubscribe(id).await;
+        });
+    }
+}
+
+fn sse_event(event: SubscriptionEvent) -> String {
+    format!(
+        "event: changed\ndata: {{\"reason\":\"{}\"}}\n\n",
+        subscription_event_reason(event)
+    )
+}
+
+fn subscription_event_reason(event: SubscriptionEvent) -> &'static str {
+    match event {
+        SubscriptionEvent::Block => "block",
+        SubscriptionEvent::Mempool => "mempool",
+        SubscriptionEvent::Reorg => "reorg",
+    }
 }
 
 fn subscription_watch_count(max_derived_index: u32) -> Result<u32, Error> {
@@ -1067,53 +1161,10 @@ pub async fn infallible_route(
     req: Request<Incoming>,
     network: Network,
     add_cors: bool,
-) -> Result<Response<Full<Bytes>>, hyper::Error> {
+) -> Result<Resp, hyper::Error> {
     let mut response = match route(state, client, req, network).await {
         Ok(r) => r,
-        Err(e) => {
-            if matches!(e, Error::CannotDecrypt) {
-                Response::builder()
-                    .status(StatusCode::UNPROCESSABLE_ENTITY)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else if matches!(e, Error::DescriptorMustHaveWildcard) {
-                Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else if matches!(e, Error::AddressPageRequiresSingleAddress) {
-                Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else if matches!(e, Error::UtxoOnlyHistoryTooLarge) {
-                Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else if matches!(e, Error::DescriptorNotScanned) {
-                Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else if matches!(e, Error::BodyTooLarge) {
-                Response::builder()
-                    .status(StatusCode::PAYLOAD_TOO_LARGE)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else if matches!(e, Error::BodyReadTimeout) {
-                Response::builder()
-                    .status(StatusCode::REQUEST_TIMEOUT)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            } else {
-                // TODO map many errors to specific status codes
-                Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Full::new(e.to_string().into()))
-                    .unwrap()
-            }
-        }
+        Err(e) => error_resp(error_status(&e), &e),
     };
 
     // Add CORS headers if enabled
@@ -1335,6 +1386,22 @@ mod tests {
         );
         assert!(subscription_watch_count(u32::MAX).is_err());
         assert!(subscription_watch_count(u32::MAX - GAP_LIMIT).is_err());
+    }
+
+    #[test]
+    fn test_sse_event() {
+        assert_eq!(
+            sse_event(SubscriptionEvent::Block),
+            "event: changed\ndata: {\"reason\":\"block\"}\n\n"
+        );
+        assert_eq!(
+            sse_event(SubscriptionEvent::Mempool),
+            "event: changed\ndata: {\"reason\":\"mempool\"}\n\n"
+        );
+        assert_eq!(
+            sse_event(SubscriptionEvent::Reorg),
+            "event: changed\ndata: {\"reason\":\"reorg\"}\n\n"
+        );
     }
 
     #[test]

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -995,6 +995,10 @@ fn sse_resp(
     });
     let events = stream::unfold((receiver, cleanup), |(mut receiver, cleanup)| async move {
         receiver.recv().await.map(|event| {
+            log::info!(
+                "subscription notification sent: id={}, event={event}",
+                cleanup.id
+            );
             (
                 Ok::<Frame<Bytes>, Infallible>(Frame::data(Bytes::from(sse_event(event)))),
                 (receiver, cleanup),
@@ -1022,7 +1026,9 @@ impl Drop for SubscriptionCleanup {
         let state = self.state.clone();
         let id = self.id;
         tokio::spawn(async move {
-            state.unsubscribe(id).await;
+            if !state.unsubscribe(id).await {
+                log::info!("subscription close requested for unknown id={id}");
+            }
         });
     }
 }

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -995,6 +995,7 @@ fn sse_resp(
     });
     let events = stream::unfold((receiver, cleanup), |(mut receiver, cleanup)| async move {
         receiver.recv().await.map(|event| {
+            crate::inc_subscription_notification_counter(event.as_str(), "sent");
             log::info!(
                 "subscription notification sent: id={}, event={event}",
                 cleanup.id

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -26,7 +26,12 @@ use std::{
 };
 use tokio::sync::Mutex;
 
-use super::{encryption, sign::MsgSigAddress, Network};
+use super::{
+    encryption,
+    sign::MsgSigAddress,
+    subscription::{SubscriptionId, SubscriptionReceiver},
+    Network,
+};
 
 /// Check if a string looks like it might be an age-encrypted payload
 pub fn is_likely_age_encrypted(s: &str) -> bool {
@@ -918,6 +923,39 @@ fn filter_utxo_only(result: &mut [Vec<TxSeen>], db: &crate::store::AnyStore) -> 
     Ok(())
 }
 
+#[allow(dead_code)]
+async fn subscribe_descriptor(
+    state: &Arc<State>,
+    descriptor: be::Descriptor,
+) -> Result<(SubscriptionId, SubscriptionReceiver), Error> {
+    let mut scripts = Vec::new();
+    for desc in descriptor.into_single_descriptors().unwrap().iter() {
+        let single_descriptor_id = string_hash(&desc.to_string());
+        let max_derived_index = state
+            .descriptor_max_derived_index(single_descriptor_id)
+            .await
+            .ok_or(Error::DescriptorNotScanned)?;
+        let watch_count = subscription_watch_count(max_derived_index)?;
+        scripts.extend(
+            derive_script_hashes_batch(state, desc, 0, watch_count)
+                .await
+                .0,
+        );
+    }
+
+    state
+        .subscribe_scripts(scripts)
+        .await
+        .map_err(|e| Error::String(format!("{e:?}")))
+}
+
+fn subscription_watch_count(max_derived_index: u32) -> Result<u32, Error> {
+    max_derived_index
+        .checked_add(GAP_LIMIT)
+        .and_then(|max_watch_index| max_watch_index.checked_add(1))
+        .ok_or_else(|| Error::String("subscription derivation range overflow".to_string()))
+}
+
 async fn find_scripts(
     state: &Arc<State>,
     db: &crate::store::AnyStore,
@@ -1049,6 +1087,11 @@ pub async fn infallible_route(
                     .body(Full::new(e.to_string().into()))
                     .unwrap()
             } else if matches!(e, Error::UtxoOnlyHistoryTooLarge) {
+                Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Full::new(e.to_string().into()))
+                    .unwrap()
+            } else if matches!(e, Error::DescriptorNotScanned) {
                 Response::builder()
                     .status(StatusCode::BAD_REQUEST)
                     .body(Full::new(e.to_string().into()))
@@ -1281,6 +1324,17 @@ mod tests {
             serializer.append_pair("page", &page.to_string());
         }
         serializer.finish()
+    }
+
+    #[test]
+    fn test_subscription_watch_count() {
+        assert_eq!(subscription_watch_count(0).unwrap(), GAP_LIMIT + 1);
+        assert_eq!(
+            subscription_watch_count(GAP_LIMIT).unwrap(),
+            GAP_LIMIT * 2 + 1
+        );
+        assert!(subscription_watch_count(u32::MAX).is_err());
+        assert!(subscription_watch_count(u32::MAX - GAP_LIMIT).is_err());
     }
 
     #[test]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -5,9 +5,13 @@ use std::{
 };
 
 use crate::{
-    server::{derivation_cache::DerivationCache, Mempool},
+    server::{
+        derivation_cache::DerivationCache,
+        subscription::{SubscriptionEvent, Subscriptions},
+        Mempool,
+    },
     store::{AnyStore, BlockMeta},
-    Timestamp,
+    ScriptHash, Timestamp,
 };
 use age::x25519::Identity;
 use bitcoin::{key::Secp256k1, secp256k1::All, PrivateKey};
@@ -18,6 +22,8 @@ use super::{sign::p2pkh, Error};
 
 const DESCRIPTOR_METRICS_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 const DESCRIPTOR_METRICS_PRUNE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const MAX_ACTIVE_SUBSCRIPTIONS: usize = 10_000;
+const MAX_SCRIPTS_PER_SUBSCRIPTION: usize = 5_000;
 
 pub struct State {
     /// An asymmetric encryption key, the public key is used to optionally encrypt the descriptor field so that it's harder to leak it.
@@ -44,6 +50,7 @@ pub struct State {
 
     descriptor_metrics: Mutex<DescriptorMetrics>,
     descriptor_max_derived_index: Mutex<HashMap<u64, u32>>,
+    subscriptions: Mutex<Subscriptions>,
 }
 
 impl State {
@@ -71,6 +78,10 @@ impl State {
             cached_fee_estimates: RwLock::new((HashMap::new(), None)),
             descriptor_metrics: Mutex::new(DescriptorMetrics::new()),
             descriptor_max_derived_index: Mutex::new(HashMap::new()),
+            subscriptions: Mutex::new(Subscriptions::new(
+                MAX_ACTIVE_SUBSCRIPTIONS,
+                MAX_SCRIPTS_PER_SUBSCRIPTION,
+            )),
         })
     }
 
@@ -141,6 +152,24 @@ impl State {
         crate::set_descriptor_max_derived_index_buckets(
             descriptor_max_derived_index.values().copied(),
         );
+    }
+
+    pub(crate) async fn notify_subscription_scripts<I>(
+        &self,
+        event: SubscriptionEvent,
+        scripts: I,
+    ) -> usize
+    where
+        I: IntoIterator<Item = ScriptHash>,
+    {
+        self.subscriptions
+            .lock()
+            .await
+            .notify_scripts(event, scripts)
+    }
+
+    pub(crate) async fn notify_all_subscriptions(&self, event: SubscriptionEvent) -> usize {
+        self.subscriptions.lock().await.notify_all(event)
     }
 }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -190,7 +190,6 @@ impl State {
         self.subscriptions.lock().await.subscribe(scripts)
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn unsubscribe(&self, id: SubscriptionId) -> bool {
         self.subscriptions.lock().await.unsubscribe(id)
     }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -52,7 +52,7 @@ pub struct State {
     pub cached_fee_estimates: RwLock<(HashMap<u16, f64>, Option<Instant>)>,
 
     descriptor_metrics: Mutex<DescriptorMetrics>,
-    descriptor_max_derived_index: Mutex<HashMap<u64, u32>>,
+    descriptor_max_used_index: Mutex<HashMap<u64, Option<u32>>>,
     subscriptions: Mutex<Subscriptions>,
 }
 
@@ -80,7 +80,7 @@ impl State {
             derivation_cache: Mutex::new(DerivationCache::new(derivation_cache_capacity)),
             cached_fee_estimates: RwLock::new((HashMap::new(), None)),
             descriptor_metrics: Mutex::new(DescriptorMetrics::new()),
-            descriptor_max_derived_index: Mutex::new(HashMap::new()),
+            descriptor_max_used_index: Mutex::new(HashMap::new()),
             subscriptions: Mutex::new(Subscriptions::new(
                 MAX_ACTIVE_SUBSCRIPTIONS,
                 MAX_SCRIPTS_PER_SUBSCRIPTION,
@@ -136,21 +136,21 @@ impl State {
         crate::set_unique_descriptors(descriptor_metrics.unique_count());
     }
 
-    pub async fn record_descriptor_max_derived_index(&self, id: u64, index: u32) {
-        let mut descriptor_max_derived_index = self.descriptor_max_derived_index.lock().await;
-        record_descriptor_max_derived_index(&mut descriptor_max_derived_index, id, index);
+    pub async fn record_descriptor_scan_max_used_index(&self, id: u64, index: Option<u32>) {
+        let mut descriptor_max_used_index = self.descriptor_max_used_index.lock().await;
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, id, index);
     }
 
-    pub(crate) async fn descriptor_max_derived_index(&self, id: u64) -> Option<u32> {
-        self.descriptor_max_derived_index
+    pub(crate) async fn descriptor_max_used_index(&self, id: u64) -> Option<Option<u32>> {
+        self.descriptor_max_used_index
             .lock()
             .await
             .get(&id)
             .copied()
     }
 
-    pub async fn descriptor_max_derived_index_snapshot(&self) -> BTreeMap<u64, u32> {
-        self.descriptor_max_derived_index
+    pub async fn descriptor_max_used_index_snapshot(&self) -> BTreeMap<u64, Option<u32>> {
+        self.descriptor_max_used_index
             .lock()
             .await
             .iter()
@@ -158,10 +158,12 @@ impl State {
             .collect()
     }
 
-    pub async fn update_descriptor_max_derived_index_metrics(&self) {
-        let descriptor_max_derived_index = self.descriptor_max_derived_index.lock().await;
-        crate::set_descriptor_max_derived_index_buckets(
-            descriptor_max_derived_index.values().copied(),
+    pub async fn update_descriptor_max_used_index_metrics(&self) {
+        let descriptor_max_used_index = self.descriptor_max_used_index.lock().await;
+        crate::set_descriptor_max_used_index_buckets(
+            descriptor_max_used_index
+                .values()
+                .filter_map(|index| *index),
         );
     }
 
@@ -195,14 +197,18 @@ impl State {
     }
 }
 
-fn record_descriptor_max_derived_index(
-    descriptor_max_derived_index: &mut HashMap<u64, u32>,
+fn record_descriptor_scan_max_used_index(
+    descriptor_max_used_index: &mut HashMap<u64, Option<u32>>,
     id: u64,
-    index: u32,
+    index: Option<u32>,
 ) {
-    descriptor_max_derived_index
+    descriptor_max_used_index
         .entry(id)
-        .and_modify(|max_index| *max_index = (*max_index).max(index))
+        .and_modify(|max_index| {
+            if let Some(index) = index {
+                *max_index = Some(max_index.map_or(index, |max_index| max_index.max(index)));
+            }
+        })
         .or_insert(index);
 }
 
@@ -352,15 +358,18 @@ mod tests {
     }
 
     #[test]
-    fn test_record_descriptor_max_derived_index() {
-        let mut descriptor_max_derived_index = HashMap::new();
+    fn test_record_descriptor_scan_max_used_index() {
+        let mut descriptor_max_used_index = HashMap::new();
 
-        record_descriptor_max_derived_index(&mut descriptor_max_derived_index, 1, 20);
-        record_descriptor_max_derived_index(&mut descriptor_max_derived_index, 1, 10);
-        record_descriptor_max_derived_index(&mut descriptor_max_derived_index, 1, 40);
-        record_descriptor_max_derived_index(&mut descriptor_max_derived_index, 2, 30);
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, 1, Some(20));
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, 1, Some(10));
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, 1, None);
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, 1, Some(40));
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, 2, None);
+        record_descriptor_scan_max_used_index(&mut descriptor_max_used_index, 3, Some(30));
 
-        assert_eq!(descriptor_max_derived_index.get(&1), Some(&40));
-        assert_eq!(descriptor_max_derived_index.get(&2), Some(&30));
+        assert_eq!(descriptor_max_used_index.get(&1), Some(&Some(40)));
+        assert_eq!(descriptor_max_used_index.get(&2), Some(&None));
+        assert_eq!(descriptor_max_used_index.get(&3), Some(&Some(30)));
     }
 }

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -7,7 +7,10 @@ use std::{
 use crate::{
     server::{
         derivation_cache::DerivationCache,
-        subscription::{SubscriptionEvent, Subscriptions},
+        subscription::{
+            SubscriptionError, SubscriptionEvent, SubscriptionId, SubscriptionReceiver,
+            Subscriptions,
+        },
         Mempool,
     },
     store::{AnyStore, BlockMeta},
@@ -138,6 +141,14 @@ impl State {
         record_descriptor_max_derived_index(&mut descriptor_max_derived_index, id, index);
     }
 
+    pub(crate) async fn descriptor_max_derived_index(&self, id: u64) -> Option<u32> {
+        self.descriptor_max_derived_index
+            .lock()
+            .await
+            .get(&id)
+            .copied()
+    }
+
     pub async fn descriptor_max_derived_index_snapshot(&self) -> BTreeMap<u64, u32> {
         self.descriptor_max_derived_index
             .lock()
@@ -170,6 +181,18 @@ impl State {
 
     pub(crate) async fn notify_all_subscriptions(&self, event: SubscriptionEvent) -> usize {
         self.subscriptions.lock().await.notify_all(event)
+    }
+
+    pub(crate) async fn subscribe_scripts(
+        &self,
+        scripts: Vec<ScriptHash>,
+    ) -> Result<(SubscriptionId, SubscriptionReceiver), SubscriptionError> {
+        self.subscriptions.lock().await.subscribe(scripts)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn unsubscribe(&self, id: SubscriptionId) -> bool {
+        self.subscriptions.lock().await.unsubscribe(id)
     }
 }
 

--- a/src/server/subscription.rs
+++ b/src/server/subscription.rs
@@ -7,11 +7,27 @@ use crate::ScriptHash;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct SubscriptionId(u64);
 
+impl std::fmt::Display for SubscriptionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SubscriptionEvent {
     Block,
     Mempool,
     Reorg,
+}
+
+impl std::fmt::Display for SubscriptionEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SubscriptionEvent::Block => "block",
+            SubscriptionEvent::Mempool => "mempool",
+            SubscriptionEvent::Reorg => "reorg",
+        })
+    }
 }
 
 pub(crate) type SubscriptionReceiver = mpsc::Receiver<SubscriptionEvent>;
@@ -70,7 +86,12 @@ impl Subscriptions {
         for script in scripts.iter().copied() {
             self.by_script.entry(script).or_default().insert(id);
         }
+        let scripts_len = scripts.len();
         self.by_id.insert(id, Subscription { scripts, sender });
+        log::info!(
+            "subscription registered: id={id}, scripts={scripts_len}, active={}",
+            self.by_id.len()
+        );
 
         Ok((id, receiver))
     }
@@ -80,6 +101,7 @@ impl Subscriptions {
             return false;
         };
 
+        let scripts_len = subscription.scripts.len();
         for script in subscription.scripts {
             if let Some(ids) = self.by_script.get_mut(&script) {
                 ids.remove(&id);
@@ -88,6 +110,10 @@ impl Subscriptions {
                 }
             }
         }
+        log::info!(
+            "subscription closed: id={id}, scripts={scripts_len}, active={}",
+            self.by_id.len()
+        );
 
         true
     }
@@ -117,6 +143,7 @@ impl Subscriptions {
         subscriptions: HashSet<SubscriptionId>,
     ) -> usize {
         let mut sent = 0;
+        let mut coalesced = 0;
         let mut closed = Vec::new();
 
         for id in subscriptions {
@@ -124,10 +151,23 @@ impl Subscriptions {
                 continue;
             };
             match subscription.sender.try_send(event) {
-                Ok(()) => sent += 1,
-                Err(mpsc::error::TrySendError::Full(_)) => {}
+                Ok(()) => {
+                    sent += 1;
+                    log::info!("subscription notification queued: id={id}, event={event}");
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    coalesced += 1;
+                    log::info!("subscription notification coalesced: id={id}, event={event}");
+                }
                 Err(mpsc::error::TrySendError::Closed(_)) => closed.push(id),
             }
+        }
+
+        if sent > 0 || coalesced > 0 || !closed.is_empty() {
+            log::info!(
+                "subscription notify summary: event={event}, sent={sent}, coalesced={coalesced}, closed={}",
+                closed.len()
+            );
         }
 
         for id in closed {

--- a/src/server/subscription.rs
+++ b/src/server/subscription.rs
@@ -14,10 +14,8 @@ pub(crate) enum SubscriptionEvent {
     Reorg,
 }
 
-#[allow(dead_code)]
 pub(crate) type SubscriptionReceiver = mpsc::Receiver<SubscriptionEvent>;
 
-#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum SubscriptionError {
     Empty,
@@ -26,11 +24,8 @@ pub(crate) enum SubscriptionError {
 }
 
 pub(crate) struct Subscriptions {
-    #[allow(dead_code)]
     next_id: u64,
-    #[allow(dead_code)]
     max_active: usize,
-    #[allow(dead_code)]
     max_scripts_per_subscription: usize,
     by_id: HashMap<SubscriptionId, Subscription>,
     by_script: HashMap<ScriptHash, HashSet<SubscriptionId>>,
@@ -52,7 +47,6 @@ impl Subscriptions {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn subscribe(
         &mut self,
         scripts: Vec<ScriptHash>,
@@ -149,7 +143,6 @@ impl Subscriptions {
     }
 }
 
-#[allow(dead_code)]
 fn deduplicate(scripts: Vec<ScriptHash>) -> Vec<ScriptHash> {
     let mut seen = HashSet::new();
     scripts

--- a/src/server/subscription.rs
+++ b/src/server/subscription.rs
@@ -20,13 +20,19 @@ pub(crate) enum SubscriptionEvent {
     Reorg,
 }
 
-impl std::fmt::Display for SubscriptionEvent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+impl SubscriptionEvent {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
             SubscriptionEvent::Block => "block",
             SubscriptionEvent::Mempool => "mempool",
             SubscriptionEvent::Reorg => "reorg",
-        })
+        }
+    }
+}
+
+impl std::fmt::Display for SubscriptionEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -153,13 +159,18 @@ impl Subscriptions {
             match subscription.sender.try_send(event) {
                 Ok(()) => {
                     sent += 1;
+                    crate::inc_subscription_notification_counter(event.as_str(), "queued");
                     log::info!("subscription notification queued: id={id}, event={event}");
                 }
                 Err(mpsc::error::TrySendError::Full(_)) => {
                     coalesced += 1;
+                    crate::inc_subscription_notification_counter(event.as_str(), "coalesced");
                     log::info!("subscription notification coalesced: id={id}, event={event}");
                 }
-                Err(mpsc::error::TrySendError::Closed(_)) => closed.push(id),
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    crate::inc_subscription_notification_counter(event.as_str(), "closed");
+                    closed.push(id);
+                }
             }
         }
 

--- a/src/server/subscription.rs
+++ b/src/server/subscription.rs
@@ -1,0 +1,265 @@
+use std::collections::{HashMap, HashSet};
+
+use tokio::sync::mpsc;
+
+use crate::ScriptHash;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct SubscriptionId(u64);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SubscriptionEvent {
+    Block,
+    Mempool,
+    Reorg,
+}
+
+#[allow(dead_code)]
+pub(crate) type SubscriptionReceiver = mpsc::Receiver<SubscriptionEvent>;
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SubscriptionError {
+    Empty,
+    TooManyScripts,
+    TooManySubscriptions,
+}
+
+pub(crate) struct Subscriptions {
+    #[allow(dead_code)]
+    next_id: u64,
+    #[allow(dead_code)]
+    max_active: usize,
+    #[allow(dead_code)]
+    max_scripts_per_subscription: usize,
+    by_id: HashMap<SubscriptionId, Subscription>,
+    by_script: HashMap<ScriptHash, HashSet<SubscriptionId>>,
+}
+
+struct Subscription {
+    scripts: Vec<ScriptHash>,
+    sender: mpsc::Sender<SubscriptionEvent>,
+}
+
+impl Subscriptions {
+    pub(crate) fn new(max_active: usize, max_scripts_per_subscription: usize) -> Self {
+        Self {
+            next_id: 0,
+            max_active,
+            max_scripts_per_subscription,
+            by_id: HashMap::new(),
+            by_script: HashMap::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn subscribe(
+        &mut self,
+        scripts: Vec<ScriptHash>,
+    ) -> Result<(SubscriptionId, SubscriptionReceiver), SubscriptionError> {
+        if self.by_id.len() >= self.max_active {
+            return Err(SubscriptionError::TooManySubscriptions);
+        }
+
+        let scripts = deduplicate(scripts);
+        if scripts.is_empty() {
+            return Err(SubscriptionError::Empty);
+        }
+        if scripts.len() > self.max_scripts_per_subscription {
+            return Err(SubscriptionError::TooManyScripts);
+        }
+
+        let id = SubscriptionId(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+
+        let (sender, receiver) = mpsc::channel(1);
+        for script in scripts.iter().copied() {
+            self.by_script.entry(script).or_default().insert(id);
+        }
+        self.by_id.insert(id, Subscription { scripts, sender });
+
+        Ok((id, receiver))
+    }
+
+    pub(crate) fn unsubscribe(&mut self, id: SubscriptionId) -> bool {
+        let Some(subscription) = self.by_id.remove(&id) else {
+            return false;
+        };
+
+        for script in subscription.scripts {
+            if let Some(ids) = self.by_script.get_mut(&script) {
+                ids.remove(&id);
+                if ids.is_empty() {
+                    self.by_script.remove(&script);
+                }
+            }
+        }
+
+        true
+    }
+
+    pub(crate) fn notify_scripts<I>(&mut self, event: SubscriptionEvent, scripts: I) -> usize
+    where
+        I: IntoIterator<Item = ScriptHash>,
+    {
+        let mut subscriptions = HashSet::new();
+        for script in scripts {
+            if let Some(ids) = self.by_script.get(&script) {
+                subscriptions.extend(ids.iter().copied());
+            }
+        }
+
+        self.notify_subscriptions(event, subscriptions)
+    }
+
+    pub(crate) fn notify_all(&mut self, event: SubscriptionEvent) -> usize {
+        let subscriptions = self.by_id.keys().copied().collect();
+        self.notify_subscriptions(event, subscriptions)
+    }
+
+    fn notify_subscriptions(
+        &mut self,
+        event: SubscriptionEvent,
+        subscriptions: HashSet<SubscriptionId>,
+    ) -> usize {
+        let mut sent = 0;
+        let mut closed = Vec::new();
+
+        for id in subscriptions {
+            let Some(subscription) = self.by_id.get(&id) else {
+                continue;
+            };
+            match subscription.sender.try_send(event) {
+                Ok(()) => sent += 1,
+                Err(mpsc::error::TrySendError::Full(_)) => {}
+                Err(mpsc::error::TrySendError::Closed(_)) => closed.push(id),
+            }
+        }
+
+        for id in closed {
+            self.unsubscribe(id);
+        }
+
+        sent
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.by_id.len()
+    }
+}
+
+#[allow(dead_code)]
+fn deduplicate(scripts: Vec<ScriptHash>) -> Vec<ScriptHash> {
+    let mut seen = HashSet::new();
+    scripts
+        .into_iter()
+        .filter(|script| seen.insert(*script))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_rejects_empty_and_too_many_scripts() {
+        let mut subscriptions = Subscriptions::new(10, 2);
+
+        assert_eq!(
+            subscriptions.subscribe(Vec::new()).unwrap_err(),
+            SubscriptionError::Empty
+        );
+        assert_eq!(
+            subscriptions.subscribe(vec![1, 2, 3]).unwrap_err(),
+            SubscriptionError::TooManyScripts
+        );
+    }
+
+    #[test]
+    fn subscribe_rejects_too_many_subscriptions() {
+        let mut subscriptions = Subscriptions::new(1, 10);
+
+        subscriptions.subscribe(vec![1]).unwrap();
+
+        assert_eq!(
+            subscriptions.subscribe(vec![2]).unwrap_err(),
+            SubscriptionError::TooManySubscriptions
+        );
+    }
+
+    #[test]
+    fn notify_scripts_fans_out_once_per_subscription() {
+        let mut subscriptions = Subscriptions::new(10, 10);
+        let (_first_id, mut first_rx) = subscriptions.subscribe(vec![1, 2]).unwrap();
+        let (_second_id, mut second_rx) = subscriptions.subscribe(vec![2, 3]).unwrap();
+
+        assert_eq!(
+            subscriptions.notify_scripts(SubscriptionEvent::Block, vec![1, 2]),
+            2
+        );
+
+        assert_eq!(first_rx.try_recv().unwrap(), SubscriptionEvent::Block);
+        assert_eq!(second_rx.try_recv().unwrap(), SubscriptionEvent::Block);
+        assert!(first_rx.try_recv().is_err());
+        assert!(second_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn notify_scripts_coalesces_when_receiver_is_full() {
+        let mut subscriptions = Subscriptions::new(10, 10);
+        let (_id, mut rx) = subscriptions.subscribe(vec![1]).unwrap();
+
+        assert_eq!(
+            subscriptions.notify_scripts(SubscriptionEvent::Block, vec![1]),
+            1
+        );
+        assert_eq!(
+            subscriptions.notify_scripts(SubscriptionEvent::Mempool, vec![1]),
+            0
+        );
+
+        assert_eq!(rx.try_recv().unwrap(), SubscriptionEvent::Block);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn unsubscribe_removes_script_index_entries() {
+        let mut subscriptions = Subscriptions::new(10, 10);
+        let (id, mut rx) = subscriptions.subscribe(vec![1, 2]).unwrap();
+
+        assert!(subscriptions.unsubscribe(id));
+        assert_eq!(
+            subscriptions.notify_scripts(SubscriptionEvent::Block, vec![1, 2]),
+            0
+        );
+        assert!(rx.try_recv().is_err());
+        assert_eq!(subscriptions.len(), 0);
+    }
+
+    #[test]
+    fn closed_receivers_are_pruned_on_notify() {
+        let mut subscriptions = Subscriptions::new(10, 10);
+        let (_id, rx) = subscriptions.subscribe(vec![1]).unwrap();
+        drop(rx);
+
+        assert_eq!(
+            subscriptions.notify_scripts(SubscriptionEvent::Block, vec![1]),
+            0
+        );
+
+        assert_eq!(subscriptions.len(), 0);
+    }
+
+    #[test]
+    fn notify_all_sends_reorg_to_every_subscription() {
+        let mut subscriptions = Subscriptions::new(10, 10);
+        let (_first_id, mut first_rx) = subscriptions.subscribe(vec![1]).unwrap();
+        let (_second_id, mut second_rx) = subscriptions.subscribe(vec![2]).unwrap();
+
+        assert_eq!(subscriptions.notify_all(SubscriptionEvent::Reorg), 2);
+
+        assert_eq!(first_rx.try_recv().unwrap(), SubscriptionEvent::Reorg);
+        assert_eq!(second_rx.try_recv().unwrap(), SubscriptionEvent::Reorg);
+    }
+}

--- a/src/store/db.rs
+++ b/src/store/db.rs
@@ -652,7 +652,7 @@ impl Store for DBStore {
         utxo_spent: Vec<(u32, OutPoint, crate::be::Txid)>,
         history_map: BTreeMap<ScriptHash, Vec<TxSeen>>,
         utxo_created: BTreeMap<OutPoint, ScriptHash>,
-    ) -> Result<()> {
+    ) -> Result<Vec<ScriptHash>> {
         let mut history_map = history_map;
 
         // First, read the script hashes for spent UTXOs (read-only operation)
@@ -665,6 +665,8 @@ impl Store for DBStore {
             let el = history_map.entry(script_hash).or_default();
             el.push(TxSeen::new(txid, block_meta.height(), V::Vin(vin)));
         }
+
+        let changed_script_hashes = history_map.keys().copied().collect::<Vec<_>>();
 
         // Create a single batch for ALL writes (atomic operation)
         // This ensures that either all data is written or none, preventing
@@ -715,7 +717,7 @@ impl Store for DBStore {
         // Single atomic write (includes reorg data)
         self.write(batch)?;
 
-        Ok(())
+        Ok(changed_script_hashes)
     }
 
     fn reorg(&self, height: Height) {

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -72,7 +72,7 @@ impl Store for MemoryStore {
         utxo_spent: Vec<(u32, OutPoint, crate::be::Txid)>,
         history_map: std::collections::BTreeMap<ScriptHash, Vec<TxSeen>>,
         utxo_created: std::collections::BTreeMap<OutPoint, ScriptHash>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<ScriptHash>> {
         let mut history_map = history_map;
         let only_outpoints: Vec<_> = utxo_spent.iter().map(|e| e.1).collect();
         let script_hashes = self.remove_utxos(&only_outpoints);
@@ -89,6 +89,8 @@ impl Store for MemoryStore {
             el.push(TxSeen::new(txid, block_meta.height(), V::Vin(vin)));
         }
 
+        let changed_script_hashes = history_map.keys().copied().collect::<Vec<_>>();
+
         // TODO: handle unwraps on the lock
         self.reorg_data.lock().unwrap().insert(
             block_meta.height(),
@@ -100,7 +102,7 @@ impl Store for MemoryStore {
         );
         self.update_history(history_map);
         self.insert_utxos(&utxo_created);
-        Ok(())
+        Ok(changed_script_hashes)
     }
 
     fn reorg(&self, height: crate::Height) {
@@ -229,7 +231,7 @@ mod tests {
         let mut utxo_created = BTreeMap::new();
         utxo_created.insert(created_outpoint, recipient_script_hash);
 
-        store
+        let changed_script_hashes = store
             .update(
                 &block_meta,
                 vec![(0, source_outpoint, spending_txid)],
@@ -237,6 +239,7 @@ mod tests {
                 utxo_created,
             )
             .unwrap();
+        assert_eq!(changed_script_hashes, vec![source_script_hash, recipient_script_hash]);
 
         assert_eq!(store.utxos.lock().unwrap().get(&source_outpoint), None);
         assert_eq!(

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -52,7 +52,7 @@ pub trait Store {
         utxo_spent: Vec<(u32, OutPoint, crate::be::Txid)>,
         history_map: BTreeMap<ScriptHash, Vec<TxSeen>>, // We want this sorted because when inserted in the write batch it's faster (see benches and test guaranteeing encoding order match struct ordering)
         utxo_created: BTreeMap<OutPoint, ScriptHash>, // We want this sorted because when inserted in the write batch it's faster (see benches and test guaranteeing encoding order match struct ordering)
-    ) -> Result<()>;
+    ) -> Result<Vec<ScriptHash>>;
 
     /// Reorg, reinsert the last block unspent utxos
     /// height: the height of the block that was reorged (needs to be rolled back)
@@ -109,7 +109,7 @@ impl Store for AnyStore {
         utxo_spent: Vec<(u32, OutPoint, crate::be::Txid)>,
         history_map: BTreeMap<ScriptHash, Vec<TxSeen>>,
         utxo_created: BTreeMap<OutPoint, ScriptHash>,
-    ) -> Result<()> {
+    ) -> Result<Vec<ScriptHash>> {
         match self {
             #[cfg(feature = "db")]
             AnyStore::Db(d) => d.update(block_meta, utxo_spent, history_map, utxo_created),

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -631,6 +631,25 @@ impl WaterfallClient {
         Ok(serde_json::from_str(&body)?)
     }
 
+    pub async fn subscribe(&self, desc: &str) -> anyhow::Result<reqwest::Response> {
+        let url = format!("{}/v1/subscribe", self.base_url);
+
+        let response = self
+            .client
+            .get(&url)
+            .query(&[("descriptor", desc)])
+            .send()
+            .await?;
+
+        let status = response.status().as_u16();
+        if status != 200 {
+            let body = response.text().await?;
+            bail!("subscribe response is not 200 but: {status} body is: {body}");
+        }
+
+        Ok(response)
+    }
+
     pub async fn wait_waterfalls_non_empty(
         &self,
         bitcoin_desc: &str,

--- a/src/threads/blocks.rs
+++ b/src/threads/blocks.rs
@@ -258,8 +258,8 @@ pub async fn index(
             }
         }
         state.set_hash_ts(&block_to_index).await;
-        let changed_script_hashes = history_map.keys().copied().collect::<Vec<_>>();
-        db.update(&block_to_index, utxo_spent, history_map, utxo_created)
+        let changed_script_hashes = db
+            .update(&block_to_index, utxo_spent, history_map, utxo_created)
             .unwrap_or_else(|e| error_panic!("error updating db: {e}"));
         state
             .notify_subscription_scripts(SubscriptionEvent::Block, changed_script_hashes)

--- a/src/threads/blocks.rs
+++ b/src/threads/blocks.rs
@@ -1,7 +1,7 @@
 use crate::{
     be::Family,
     fetch::{ChainStatus, Client},
-    server::{Error, State},
+    server::{Error, State, SubscriptionEvent},
     store::{BlockMeta, Store},
     OutPoint, TxSeen, V,
 };
@@ -78,6 +78,9 @@ async fn get_next_block_to_index(
                     );
                     *last_indexed = Some(previous_block_meta);
                     state.store.reorg(reorged_height);
+                    state
+                        .notify_all_subscriptions(SubscriptionEvent::Reorg)
+                        .await;
                     log::info!(
                         "reorg: store.reorg() completed, will re-fetch block at height {}",
                         reorged_height
@@ -255,8 +258,12 @@ pub async fn index(
             }
         }
         state.set_hash_ts(&block_to_index).await;
+        let changed_script_hashes = history_map.keys().copied().collect::<Vec<_>>();
         db.update(&block_to_index, utxo_spent, history_map, utxo_created)
             .unwrap_or_else(|e| error_panic!("error updating db: {e}"));
+        state
+            .notify_subscription_scripts(SubscriptionEvent::Block, changed_script_hashes)
+            .await;
 
         crate::BLOCKCHAIN_TIP.set(block_to_index.height as i64);
         last_indexed = Some(block_to_index);

--- a/src/threads/mempool.rs
+++ b/src/threads/mempool.rs
@@ -2,7 +2,7 @@ use crate::{
     be::Family,
     cache_counter,
     fetch::Client,
-    server::{Error, State},
+    server::{Error, State, SubscriptionEvent},
     store::Store,
 };
 use std::{
@@ -107,9 +107,9 @@ async fn sync_mempool_once(
                 .iter()
                 .filter_map(|txid| mempool_cache.get(txid).map(|tx| (*txid, tx)))
                 .collect();
-            {
+            let changed_script_hashes = {
                 let mut m = state.mempool.lock().await;
-                m.update(db, &removed, &txs);
+                let changed_script_hashes = m.update(db, &removed, &txs);
                 mempool_txids.clear();
                 mempool_txids.extend(m.txids_iter());
                 if is_big_delta {
@@ -123,7 +123,11 @@ async fn sync_mempool_once(
                         txs.len(),
                     );
                 }
-            }
+                changed_script_hashes
+            };
+            state
+                .notify_subscription_scripts(SubscriptionEvent::Mempool, changed_script_hashes)
+                .await;
             mempool_cache.clear();
             let processing_time = start.elapsed();
             if is_big_delta {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -348,16 +348,19 @@ async fn do_test_subscribe_notifies_descriptor_change(test_env: waterfalls::test
             .unwrap(),
         "text/event-stream"
     );
-    let mut response = response;
+    let mut sse = SseTestReader::new(response);
 
     let addr = subscription_test_address(test_env.family, &single_desc, 20);
     test_env.send_to(&addr, 10_000);
 
-    let event = wait_sse_changed_event(&mut response).await;
+    let event = sse.next_changed_event().await;
     assert!(
-        event.contains("\"reason\":\"mempool\"") || event.contains("\"reason\":\"block\""),
+        event.contains("\"reason\":\"mempool\""),
         "unexpected SSE event: {event}"
     );
+
+    test_env.node_generate(1).await;
+    sse.wait_changed_reason("block").await;
 
     test_env.shutdown().await;
 }
@@ -435,19 +438,64 @@ async fn launch_memory() -> waterfalls::test_env::TestEnv<'static> {
 }
 
 #[cfg(feature = "test_env")]
-async fn wait_sse_changed_event(response: &mut reqwest::Response) -> String {
-    timeout(Duration::from_secs(10), async {
-        let mut received = String::new();
-        while let Some(chunk) = response.chunk().await.unwrap() {
-            received.push_str(std::str::from_utf8(chunk.as_ref()).unwrap());
-            if received.contains("event: changed") {
-                return received;
-            }
+struct SseTestReader {
+    response: reqwest::Response,
+    buffer: String,
+}
+
+#[cfg(feature = "test_env")]
+impl SseTestReader {
+    fn new(response: reqwest::Response) -> Self {
+        Self {
+            response,
+            buffer: String::new(),
         }
-        panic!("SSE stream ended before changed event, received: {received}");
-    })
-    .await
-    .expect("timed out waiting for SSE changed event")
+    }
+
+    async fn next_changed_event(&mut self) -> String {
+        timeout(Duration::from_secs(10), async {
+            loop {
+                if let Some(event) = self.pop_event() {
+                    if event.contains("event: changed") {
+                        return event;
+                    }
+                    continue;
+                }
+
+                let Some(chunk) = self.response.chunk().await.unwrap() else {
+                    panic!(
+                        "SSE stream ended before changed event, buffered: {}",
+                        self.buffer
+                    );
+                };
+                self.buffer
+                    .push_str(std::str::from_utf8(chunk.as_ref()).unwrap());
+            }
+        })
+        .await
+        .expect("timed out waiting for SSE changed event")
+    }
+
+    async fn wait_changed_reason(&mut self, reason: &str) -> String {
+        let expected = format!("\"reason\":\"{reason}\"");
+        timeout(Duration::from_secs(10), async {
+            loop {
+                let event = self.next_changed_event().await;
+                if event.contains(&expected) {
+                    return event;
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for SSE changed event reason {reason}"))
+    }
+
+    fn pop_event(&mut self) -> Option<String> {
+        let end = self.buffer.find("\n\n")?;
+        let event = self.buffer[..end + 2].to_string();
+        self.buffer.drain(..end + 2);
+        Some(event)
+    }
 }
 
 #[cfg(feature = "test_env")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -297,48 +297,50 @@ async fn integration_descriptor_has_more_contains_addresses() {
 
 #[cfg(feature = "test_env")]
 #[tokio::test]
-async fn integration_subscribe_notifies_descriptor_change() {
+async fn integration_subscribe_notifies_descriptor_change_bitcoin() {
     let _ = env_logger::try_init();
 
     let test_env = launch_memory(Family::Bitcoin).await;
-    let single_bitcoin_desc =
-        "wpkh(tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M/0/*)";
+    do_test_subscribe_notifies_descriptor_change(test_env).await;
+}
 
-    let err = test_env
-        .client()
-        .subscribe(single_bitcoin_desc)
-        .await
-        .unwrap_err();
+#[cfg(feature = "test_env")]
+#[tokio::test]
+async fn integration_subscribe_notifies_descriptor_change_liquid() {
+    let _ = env_logger::try_init();
+
+    let test_env = launch_memory(Family::Elements).await;
+    do_test_subscribe_notifies_descriptor_change(test_env).await;
+}
+
+#[cfg(feature = "test_env")]
+async fn do_test_subscribe_notifies_descriptor_change(test_env: waterfalls::test_env::TestEnv) {
+    let tpub = "tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M";
+    let prefix = match test_env.family {
+        Family::Bitcoin => "",
+        Family::Elements => "el",
+    };
+    let single_desc = format!("{prefix}wpkh({tpub}/0/*)");
+
+    let err = test_env.client().subscribe(&single_desc).await.unwrap_err();
     assert_eq!(
         format!("{err:?}"),
         "subscribe response is not 200 but: 400 body is: DescriptorNotScanned"
     );
 
-    let desc = be::bitcoin_descriptor(single_bitcoin_desc).unwrap();
-    let addr_0 = desc
-        .bitcoin()
-        .unwrap()
-        .at_derivation_index(0)
-        .unwrap()
-        .address(bitcoin::Network::Regtest)
-        .unwrap();
-    let addr_0 = be::Address::Bitcoin(addr_0);
+    let addr_0 = subscription_test_address(test_env.family, &single_desc, 0);
     test_env.send_to(&addr_0, 10_000);
     test_env.node_generate(1).await;
 
     let result = test_env
         .client()
-        .waterfalls_v2(single_bitcoin_desc)
+        .waterfalls_v2(&single_desc)
         .await
         .unwrap()
         .0;
     assert!(!result.is_empty());
 
-    let response = test_env
-        .client()
-        .subscribe(single_bitcoin_desc)
-        .await
-        .unwrap();
+    let response = test_env.client().subscribe(&single_desc).await.unwrap();
     assert_eq!(
         response
             .headers()
@@ -348,15 +350,7 @@ async fn integration_subscribe_notifies_descriptor_change() {
     );
     let mut response = response;
 
-    let addr = desc
-        .bitcoin()
-        .unwrap()
-        .at_derivation_index(20)
-        .unwrap()
-        .address(bitcoin::Network::Regtest)
-        .unwrap();
-    let addr = be::Address::Bitcoin(addr);
-
+    let addr = subscription_test_address(test_env.family, &single_desc, 20);
     test_env.send_to(&addr, 10_000);
 
     let event = wait_sse_changed_event(&mut response).await;
@@ -366,6 +360,39 @@ async fn integration_subscribe_notifies_descriptor_change() {
     );
 
     test_env.shutdown().await;
+}
+
+#[cfg(feature = "test_env")]
+fn subscription_test_address(family: Family, descriptor: &str, index: u32) -> be::Address {
+    match family {
+        Family::Bitcoin => {
+            let desc = be::bitcoin_descriptor(descriptor).unwrap();
+            let addr = desc
+                .bitcoin()
+                .unwrap()
+                .at_derivation_index(index)
+                .unwrap()
+                .address(bitcoin::Network::Regtest)
+                .unwrap();
+            be::Address::Bitcoin(addr)
+        }
+        Family::Elements => {
+            use elements_miniscript::{ConfidentialDescriptor, DescriptorPublicKey};
+            use std::str::FromStr;
+
+            let blinding =
+                "slip77(9c8e4f05c7711a98c838be228bcb84924d4570ca53f35fa1c793e58841d47023)";
+            let desc_str = format!("ct({blinding},{descriptor})");
+            let desc = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(&desc_str).unwrap();
+            let secp = elements::bitcoin::secp256k1::Secp256k1::new();
+            let addr = desc
+                .at_derivation_index(index)
+                .unwrap()
+                .address(&secp, &AddressParams::ELEMENTS)
+                .unwrap();
+            be::Address::Elements(addr)
+        }
+    }
 }
 
 #[cfg(all(feature = "test_env", feature = "db"))]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -360,7 +360,11 @@ async fn do_test_subscribe_notifies_descriptor_change(test_env: waterfalls::test
     );
 
     test_env.node_generate(1).await;
-    sse.wait_changed_reason("block").await;
+    let event = sse.next_changed_event().await;
+    assert!(
+        event.contains("\"reason\":\"block\""),
+        "unexpected SSE event: {event}"
+    );
 
     test_env.shutdown().await;
 }
@@ -474,20 +478,6 @@ impl SseTestReader {
         })
         .await
         .expect("timed out waiting for SSE changed event")
-    }
-
-    async fn wait_changed_reason(&mut self, reason: &str) -> String {
-        let expected = format!("\"reason\":\"{reason}\"");
-        timeout(Duration::from_secs(10), async {
-            loop {
-                let event = self.next_changed_event().await;
-                if event.contains(&expected) {
-                    return event;
-                }
-            }
-        })
-        .await
-        .unwrap_or_else(|_| panic!("timed out waiting for SSE changed event reason {reason}"))
     }
 
     fn pop_event(&mut self) -> Option<String> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -304,6 +304,16 @@ async fn integration_subscribe_notifies_descriptor_change() {
     let single_bitcoin_desc =
         "wpkh(tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M/0/*)";
 
+    let err = test_env
+        .client()
+        .subscribe(single_bitcoin_desc)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        format!("{err:?}"),
+        "subscribe response is not 200 but: 400 body is: DescriptorNotScanned"
+    );
+
     let desc = be::bitcoin_descriptor(single_bitcoin_desc).unwrap();
     let addr_0 = desc
         .bitcoin()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -304,13 +304,25 @@ async fn integration_subscribe_notifies_descriptor_change() {
     let single_bitcoin_desc =
         "wpkh(tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M/0/*)";
 
+    let desc = be::bitcoin_descriptor(single_bitcoin_desc).unwrap();
+    let addr_0 = desc
+        .bitcoin()
+        .unwrap()
+        .at_derivation_index(0)
+        .unwrap()
+        .address(bitcoin::Network::Regtest)
+        .unwrap();
+    let addr_0 = be::Address::Bitcoin(addr_0);
+    test_env.send_to(&addr_0, 10_000);
+    test_env.node_generate(1).await;
+
     let result = test_env
         .client()
         .waterfalls_v2(single_bitcoin_desc)
         .await
         .unwrap()
         .0;
-    assert!(result.is_empty());
+    assert!(!result.is_empty());
 
     let response = test_env
         .client()
@@ -326,11 +338,10 @@ async fn integration_subscribe_notifies_descriptor_change() {
     );
     let mut response = response;
 
-    let desc = be::bitcoin_descriptor(single_bitcoin_desc).unwrap();
     let addr = desc
         .bitcoin()
         .unwrap()
-        .at_derivation_index(21)
+        .at_derivation_index(20)
         .unwrap()
         .address(bitcoin::Network::Regtest)
         .unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -295,6 +295,58 @@ async fn integration_descriptor_has_more_contains_addresses() {
     test_env.shutdown().await;
 }
 
+#[cfg(feature = "test_env")]
+#[tokio::test]
+async fn integration_subscribe_notifies_descriptor_change() {
+    let _ = env_logger::try_init();
+
+    let test_env = launch_memory(Family::Bitcoin).await;
+    let single_bitcoin_desc =
+        "wpkh(tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M/0/*)";
+
+    let result = test_env
+        .client()
+        .waterfalls_v2(single_bitcoin_desc)
+        .await
+        .unwrap()
+        .0;
+    assert!(result.is_empty());
+
+    let response = test_env
+        .client()
+        .subscribe(single_bitcoin_desc)
+        .await
+        .unwrap();
+    assert_eq!(
+        response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .unwrap(),
+        "text/event-stream"
+    );
+    let mut response = response;
+
+    let desc = be::bitcoin_descriptor(single_bitcoin_desc).unwrap();
+    let addr = desc
+        .bitcoin()
+        .unwrap()
+        .at_derivation_index(21)
+        .unwrap()
+        .address(bitcoin::Network::Regtest)
+        .unwrap();
+    let addr = be::Address::Bitcoin(addr);
+
+    test_env.send_to(&addr, 10_000);
+
+    let event = wait_sse_changed_event(&mut response).await;
+    assert!(
+        event.contains("\"reason\":\"mempool\"") || event.contains("\"reason\":\"block\""),
+        "unexpected SSE event: {event}"
+    );
+
+    test_env.shutdown().await;
+}
+
 #[cfg(all(feature = "test_env", feature = "db"))]
 #[tokio::test]
 async fn integration_db_elements() {
@@ -332,6 +384,22 @@ async fn launch_memory(family: Family) -> waterfalls::test_env::TestEnv {
 async fn launch_memory() -> waterfalls::test_env::TestEnv<'static> {
     let exe = std::env::var("ELEMENTSD_EXEC").unwrap();
     waterfalls::test_env::launch(exe).await
+}
+
+#[cfg(feature = "test_env")]
+async fn wait_sse_changed_event(response: &mut reqwest::Response) -> String {
+    timeout(Duration::from_secs(10), async {
+        let mut received = String::new();
+        while let Some(chunk) = response.chunk().await.unwrap() {
+            received.push_str(std::str::from_utf8(chunk.as_ref()).unwrap());
+            if received.contains("event: changed") {
+                return received;
+            }
+        }
+        panic!("SSE stream ended before changed event, received: {received}");
+    })
+    .await
+    .expect("timed out waiting for SSE changed event")
 }
 
 #[cfg(feature = "test_env")]


### PR DESCRIPTION
Add the endpoint subscribe which allows to subscribe to events happening on a given descriptor.

We can use a SSE endpoint because only the server send events to the client, thus real bi-directional communication like a web socket is not needed

There is a back and forth on the per descriptor stored value (firstly max derived address + 20, then max derived address, then max used address)


TODO: make following const program parameters
```
const MAX_ACTIVE_SUBSCRIPTIONS: usize = 10_000;
const MAX_SCRIPTS_PER_SUBSCRIPTION: usize = 5_000;
```

TODO/TOCONSIDER:
When MAX_SCRIPTS_PER_SUBSCRIPTION is not enough to cover a descriptor up to the last used address + GAP_LIMIT, instead of failing, consider the last MAX_SCRIPTS_PER_SUBSCRIPTION scripts