### PR TITLE
Subscribe before scan

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -167,7 +167,7 @@ To get the next unused external address, use index `external + 1` (or index `0` 
 GET /v1/subscribe?descriptor=<descriptor>
 ```
 
-Opens a Server-Sent Events (SSE) stream that notifies the client when a previously scanned descriptor may have new activity. The notification is only a hint; clients should perform the normal Waterfalls scan after receiving an event.
+Opens a Server-Sent Events (SSE) stream that notifies the client when a descriptor may have new activity. The notification is only a hint; clients should perform the normal Waterfalls scan after receiving an event.
 
 **Query Parameters:**
 
@@ -176,12 +176,12 @@ Opens a Server-Sent Events (SSE) stream that notifies the client when a previous
   - Network validation: mainnet descriptors (xpub) cannot be used on testnet/regtest
   - Must have a wildcard
 
-**Precondition:**
+**Subscription Range:**
 
-- The descriptor must have been scanned with `/v1/waterfalls`, `/v2/waterfalls`, or `/v4/waterfalls` before subscribing
-- If the descriptor has never been scanned, the server returns `400 DescriptorNotScanned`
-- The server tracks the highest used derivation index observed during scans
-- Subscriptions watch scripts up to `max_used_index + GAP_LIMIT`; if a descriptor was scanned but has no used index yet, the initial gap window is watched
+- The descriptor does not need to have been scanned before subscribing
+- If the descriptor has never been scanned, the server performs an internal bounded usage scan before opening the stream
+- The server tracks the highest used derivation index observed during scans and first-time subscriptions
+- Subscriptions watch scripts up to `max_used_index + GAP_LIMIT`; if no used index is found, the initial gap window is watched
 
 **Response:**
 
@@ -226,9 +226,10 @@ For each newly indexed block, each subscription receives either `block` or `tip`
 
 **Client Behavior:**
 
+- To avoid missing updates between an initial scan and subscription setup, clients should open the subscription first, then run the usual Waterfalls scan
 - Treat events as invalidation hints, not as wallet updates
 - On any `update` event, run the usual Waterfalls scan to obtain authoritative history and tip state
-- On reconnect, run a Waterfalls scan before relying on subscription events, because events may have been missed while disconnected
+- On reconnect, re-open the subscription, then run a Waterfalls scan, because events may have been missed while disconnected
 
 ## Base Endpoints
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -400,7 +400,6 @@ pub enum Error {
     TooManyAddresses,
     AddressPageRequiresSingleAddress,
     DescriptorMustHaveWildcard,
-    DescriptorNotScanned,
     UtxoOnlyHistoryTooLarge,
     BodyTooLarge,
     BodyReadTimeout,

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -979,10 +979,16 @@ async fn subscribe_descriptor(
     let mut scripts = Vec::new();
     for desc in descriptor.into_single_descriptors().unwrap().iter() {
         let single_descriptor_id = string_hash(&desc.normalized_id_string());
-        let max_used_index = state
-            .descriptor_max_used_index(single_descriptor_id)
-            .await
-            .ok_or(Error::DescriptorNotScanned)?;
+        let max_used_index = match state.descriptor_max_used_index(single_descriptor_id).await {
+            Some(max_used_index) => max_used_index,
+            None => {
+                let max_used_index = scan_descriptor_max_used_index(state, desc).await;
+                state
+                    .record_descriptor_scan_max_used_index(single_descriptor_id, max_used_index)
+                    .await;
+                max_used_index
+            }
+        };
         let watch_count = subscription_watch_count(max_used_index)?;
         scripts.extend(
             derive_script_hashes_batch(state, desc, 0, watch_count)
@@ -995,6 +1001,27 @@ async fn subscribe_descriptor(
         .subscribe_scripts(scripts)
         .await
         .map_err(|e| Error::String(format!("{e:?}")))
+}
+
+async fn scan_descriptor_max_used_index(state: &Arc<State>, desc: &be::Descriptor) -> Option<u32> {
+    let mut max_used_index = None;
+
+    for batch in 0..MAX_BATCH {
+        let batch_start = batch * GAP_LIMIT;
+        let (scripts, _) = derive_script_hashes_batch(state, desc, batch_start, GAP_LIMIT).await;
+
+        let mut result = Vec::with_capacity(GAP_LIMIT as usize);
+        let find_result = find_scripts(state, &state.store, &mut result, scripts, 0, true).await;
+        if let Some(max_used_offset) = find_result.max_used_offset {
+            max_used_index = Some(batch_start + max_used_offset);
+        }
+
+        if find_result.is_last {
+            break;
+        }
+    }
+
+    max_used_index
 }
 
 fn sse_resp(

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -563,8 +563,7 @@ fn error_status(error: &Error) -> StatusCode {
         | Error::TooManyAddresses
         | Error::DescriptorMustHaveWildcard
         | Error::AddressPageRequiresSingleAddress
-        | Error::UtxoOnlyHistoryTooLarge
-        | Error::DescriptorNotScanned => StatusCode::BAD_REQUEST,
+        | Error::UtxoOnlyHistoryTooLarge => StatusCode::BAD_REQUEST,
         Error::BodyTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
         Error::BodyReadTimeout => StatusCode::REQUEST_TIMEOUT,
         _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -326,23 +326,11 @@ async fn do_test_subscribe_notifies_descriptor_change(test_env: waterfalls::test
     };
     let single_desc = format!("{prefix}wpkh({tpub}/0/*)");
 
-    let err = test_env.client().subscribe(&single_desc).await.unwrap_err();
-    assert_eq!(
-        format!("{err:?}"),
-        "subscribe response is not 200 but: 400 body is: DescriptorNotScanned"
-    );
-
     let addr_0 = subscription_test_address(test_env.family, &single_desc, 0);
     test_env.send_to(&addr_0, 10_000);
+    let addr_20 = subscription_test_address(test_env.family, &single_desc, 20);
+    test_env.send_to(&addr_20, 10_000);
     test_env.node_generate(1).await;
-
-    let result = test_env
-        .client()
-        .waterfalls_v2(&single_desc)
-        .await
-        .unwrap()
-        .0;
-    assert!(!result.is_empty());
 
     let response = test_env.client().subscribe(&single_desc).await.unwrap();
     assert_eq!(
@@ -354,7 +342,7 @@ async fn do_test_subscribe_notifies_descriptor_change(test_env: waterfalls::test
     );
     let mut sse = SseTestReader::new(response);
 
-    let addr = subscription_test_address(test_env.family, &single_desc, 20);
+    let addr = subscription_test_address(test_env.family, &single_desc, 40);
     test_env.send_to(&addr, 10_000);
 
     let event = sse.next_update_event().await;


### PR DESCRIPTION
The `Error::DescriptorNotScanned` make sense from a server efficiency perspective. However it requires clients to always do:

1.scan 2.subscribe 3.scan because some events could happens between 1 and 2.

By allowing to call subscribe even for never seen descriptor, the clients can simply do

1.subscribe 2.scan

Which is highly desirable