### PR TITLE
Subscribe keepalive

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -194,6 +194,14 @@ Opens a Server-Sent Events (SSE) stream that notifies the client when a descript
 
 ```
 
+While the subscription is idle, the server sends an SSE comment every 30 seconds to keep the
+connection alive:
+
+```text
+: keepalive
+
+```
+
 When an update is available, the server sends:
 
 ```text

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -27,6 +27,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::Mutex;
+use tokio::time::Interval;
 
 use super::{
     encryption,
@@ -54,6 +55,8 @@ const MAX_ADDRESS_LENGTH: usize = 100; // max characters for an address (excessi
 const MAX_TX_BODY_SIZE: usize = 1024 * 1024; // 1MB limit for transaction broadcast body
 const BODY_READ_TIMEOUT: Duration = Duration::from_secs(30); // timeout for reading request body
 const FEE_ESTIMATES_TTL: u32 = 30; // cache fee estimates for 30 seconds
+const SSE_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+const SSE_KEEPALIVE: &[u8] = b": keepalive\n\n";
 
 type RespBody = BoxBody<Bytes, Infallible>;
 type Resp = Response<RespBody>;
@@ -1032,26 +1035,27 @@ fn sse_resp(
     let ready = stream::once(async {
         Ok::<Frame<Bytes>, Infallible>(Frame::data(Bytes::from_static(b": ready\n\n")))
     });
-    let events = stream::unfold((receiver, cleanup), |(mut receiver, cleanup)| async move {
-        receiver.recv().await.map(|event| {
-            crate::inc_subscription_notification_counter(event.as_str(), "sent");
-            log::info!(
-                "subscription notification sent: id={}, event={event}",
-                cleanup.id
-            );
-            let state = cleanup.state.clone();
-            (
-                async move {
-                    Ok::<Frame<Bytes>, Infallible>(Frame::data(Bytes::from(sse_event(
-                        event,
-                        state.tip().await,
-                    ))))
-                },
-                (receiver, cleanup),
-            )
-        })
-    });
-    let events = events.then(|frame| frame);
+    let keepalive = keepalive_interval(SSE_KEEPALIVE_INTERVAL);
+    let events = stream::unfold(
+        (receiver, cleanup, keepalive),
+        |(mut receiver, cleanup, mut keepalive)| async move {
+            let bytes = match next_subscription_message(&mut receiver, &mut keepalive).await? {
+                SubscriptionMessage::Event(event) => {
+                    crate::inc_subscription_notification_counter(event.as_str(), "sent");
+                    log::info!(
+                        "subscription notification sent: id={}, event={event}",
+                        cleanup.id
+                    );
+                    Bytes::from(sse_event(event, cleanup.state.tip().await))
+                }
+                SubscriptionMessage::Keepalive => Bytes::from_static(SSE_KEEPALIVE),
+            };
+            Some((
+                Ok::<Frame<Bytes>, Infallible>(Frame::data(bytes)),
+                (receiver, cleanup, keepalive),
+            ))
+        },
+    );
     let body = BodyExt::boxed(StreamBody::new(ready.chain(events)));
 
     Response::builder()
@@ -1061,6 +1065,27 @@ fn sse_resp(
         .header("X-Accel-Buffering", "no")
         .body(body)
         .map_err(|_| Error::Other)
+}
+
+enum SubscriptionMessage {
+    Event(SubscriptionEvent),
+    Keepalive,
+}
+
+async fn next_subscription_message(
+    receiver: &mut SubscriptionReceiver,
+    keepalive: &mut Interval,
+) -> Option<SubscriptionMessage> {
+    tokio::select! {
+        event = receiver.recv() => event.map(SubscriptionMessage::Event),
+        _ = keepalive.tick() => Some(SubscriptionMessage::Keepalive),
+    }
+}
+
+fn keepalive_interval(period: Duration) -> Interval {
+    let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval
 }
 
 struct SubscriptionCleanup {

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -1344,6 +1344,7 @@ fn get_build_info() -> BuildInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::subscription::Subscriptions;
 
     const MAINNET_DESC: &str = "elwpkh([a12b02f4/44'/0'/0']xpub6BzhLAQUDcBUfHRQHZxDF2AbcJqp4Kaeq6bzJpXrjrWuK26ymTFwkEFbxPra2bJ7yeZKbDjfDeFwxe93JMqpo5SsPJH6dZdvV9kMzJkAZ69/0/*)#20ufqv7z";
     const TESTNET_DESC: &str = "elwpkh(tpubDC8msFGeGuwnKG9Upg7DM2b4DaRqg3CUZa5g8v2SRQ6K4NSkxUgd7HsL2XVWbVm39yBA4LAxysQAm397zwQSQoQgewGiYZqrA9DsP4zbQ1M/<0;1>/*)#v7pu3vak";
@@ -1575,6 +1576,30 @@ mod tests {
                 test_tip().b
             )
         );
+    }
+
+    #[tokio::test]
+    async fn sse_keepalive_waits_for_interval() {
+        let mut subscriptions = Subscriptions::new(1, 1);
+        let (_id, mut receiver) = subscriptions.subscribe(vec![1]).unwrap();
+        let mut keepalive = keepalive_interval(Duration::from_millis(20));
+
+        assert!(tokio::time::timeout(
+            Duration::from_millis(1),
+            next_subscription_message(&mut receiver, &mut keepalive)
+        )
+        .await
+        .is_err());
+
+        let message = tokio::time::timeout(
+            Duration::from_secs(1),
+            next_subscription_message(&mut receiver, &mut keepalive),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(matches!(message, SubscriptionMessage::Keepalive));
+        assert_eq!(SSE_KEEPALIVE, b": keepalive\n\n");
     }
 
     fn test_tip() -> crate::BlockMeta {


### PR DESCRIPTION
Send 

```text
: keepalive
```

over the subscribe connection every 30 seconds to keep alive the connection

on the SSE connection everything starting with `:` is considered comment and is discarded by clients (this change is not breaking compatibility with existing client)