### PR TITLE
Optionally add Server-Timing to response

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -119,6 +119,10 @@ pub struct Arguments {
     #[arg(env, long)]
     pub add_cors: bool,
 
+    /// Add total server processing time to descriptor endpoint responses using the Server-Timing header
+    #[arg(env, long)]
+    pub server_timing: bool,
+
     /// Maximum capacity for the derivation cache
     #[arg(env, long, default_value = "1000000")]
     pub derivation_cache_capacity: usize,
@@ -202,6 +206,7 @@ impl std::fmt::Debug for Arguments {
             .field("max_addresses", &self.max_addresses)
             .field("max_txs_seen", &self.max_txs_seen)
             .field("add_cors", &self.add_cors)
+            .field("server_timing", &self.server_timing)
             .field("derivation_cache_capacity", &self.derivation_cache_capacity)
             .field("max_active_subscriptions", &self.max_active_subscriptions)
             .field(
@@ -273,6 +278,18 @@ impl Arguments {
 #[cfg(test)]
 mod argument_tests {
     use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn server_timing_is_opt_in() {
+        let args = Arguments::try_parse_from(["waterfalls", "--network", "liquid"]).unwrap();
+        assert!(!args.server_timing);
+
+        let args =
+            Arguments::try_parse_from(["waterfalls", "--network", "liquid", "--server-timing"])
+                .unwrap();
+        assert!(args.server_timing);
+    }
 
     #[test]
     fn deprecated_rpc_user_password_keeps_node_mode_valid() {
@@ -482,6 +499,7 @@ pub async fn inner_main(
             max_addresses: args.max_addresses,
             max_txs_seen: args.max_txs_seen.unwrap_or(DEFAULT_MAX_TXS_SEEN),
             cache_control_seconds: args.cache_control_seconds,
+            server_timing: args.server_timing,
             derivation_cache_capacity: args.derivation_cache_capacity,
             subscription_limits: SubscriptionLimits {
                 max_active_subscriptions: args

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -681,6 +681,7 @@ async fn handle_waterfalls_req(
 ) -> Result<Resp, Error> {
     let db = &state.store;
     let start = Instant::now();
+    let is_descriptor = inputs.descriptor().is_some();
     let page = inputs.page();
     let mut derivations_duration = Duration::from_secs(0);
 
@@ -862,13 +863,26 @@ async fn handle_waterfalls_req(
     crate::WATERFALLS_COUNTER.inc();
     timer.observe_duration();
 
-    any_resp(
+    let mut response = any_resp(
         result,
         hyper::StatusCode::OK,
         Some(content),
         Some(state.cache_control_seconds),
         Some(m),
-    )
+    )?;
+    if state.server_timing && is_descriptor {
+        add_server_timing_header(&mut response, start.elapsed())?;
+    }
+    Ok(response)
+}
+
+fn add_server_timing_header(response: &mut Resp, duration: Duration) -> Result<(), Error> {
+    let duration_ms = duration.as_secs_f64() * 1_000.0;
+    let value = format!("total;dur={duration_ms:.3}")
+        .parse()
+        .map_err(|_| Error::Other)?;
+    response.headers_mut().insert("server-timing", value);
+    Ok(())
 }
 
 /// Handle the last_used_index endpoint request
@@ -1542,6 +1556,18 @@ mod tests {
     fn test_invalid_descriptor_is_bad_request() {
         let error = Error::InvalidDescriptor("BadDescriptor".to_string());
         assert_eq!(error_status(&error), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn server_timing_header_uses_milliseconds() {
+        let mut response = str_resp(String::new(), StatusCode::OK).unwrap();
+
+        add_server_timing_header(&mut response, Duration::from_micros(1_234)).unwrap();
+
+        assert_eq!(
+            response.headers().get("server-timing").unwrap(),
+            "total;dur=1.234"
+        );
     }
 
     #[test]

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -45,6 +45,8 @@ pub struct State {
 
     pub cache_control_seconds: u32,
 
+    pub server_timing: bool,
+
     pub derivation_cache: Mutex<DerivationCache>,
 
     pub cached_fee_estimates: RwLock<(HashMap<u16, f64>, Option<Instant>)>,
@@ -72,6 +74,7 @@ impl State {
             max_addresses: config.max_addresses,
             max_txs_seen: config.max_txs_seen,
             cache_control_seconds: config.cache_control_seconds,
+            server_timing: config.server_timing,
             derivation_cache: Mutex::new(DerivationCache::new(config.derivation_cache_capacity)),
             cached_fee_estimates: RwLock::new((HashMap::new(), None)),
             descriptor_metrics: Mutex::new(DescriptorMetrics::new()),
@@ -291,6 +294,7 @@ pub struct StateConfig {
     pub max_addresses: usize,
     pub max_txs_seen: usize,
     pub cache_control_seconds: u32,
+    pub server_timing: bool,
     pub derivation_cache_capacity: usize,
     pub subscription_limits: SubscriptionLimits,
 }

--- a/src/threads/blocks.rs
+++ b/src/threads/blocks.rs
@@ -362,6 +362,7 @@ mod tests {
                 max_addresses: 100,
                 max_txs_seen: 100,
                 cache_control_seconds: 5,
+                server_timing: false,
                 derivation_cache_capacity: 1000,
                 subscription_limits: SubscriptionLimits {
                     max_active_subscriptions: 100,


### PR DESCRIPTION
This is a standard header https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing that could help measuring instance performance. Since it can also be used to gather information to dos the server it is opt-in